### PR TITLE
All platforms use Path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 use std::env;
 use std::fs;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::path::Path;
 use std::path::PathBuf;
 


### PR DESCRIPTION
The configuration code was tidied up to pass around a Path instead of a string, which is much neater (#8).

But now all platforms use the Path in config.rs, so removing the conditional compile option. 