### PR TITLE
Make gitleaks scan work on windows

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,8 +47,8 @@ impl Default for GitleaksConfig {
                 "9ed4271ffbfa04feec1423eb56154ad22c11ac4cae698f0115c1a064d4553524",
             ),
             ("8.12.0", "windows", "x86_64") => (
-                "gitleaks-8.12.0-windows-x86_64.exe",
-                "d7a49162a15133958d3e4b8c0967581fe3069e81847978ad5b5f6903a9f6fa88",
+                "gitleaks-8.16.1-windows-x86_64.exe",
+                "9cfad211670cbfd8550b7512a145d9b1b9276ea6ec3fafb990218b6c0716f512",
             ),
             _ => ("gitleaks-unknown-unknown-unknown", "UNSUPPORTED"),
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,11 +34,22 @@ impl Default for GitleaksConfig {
         let version = "8.12.0";
 
         let (filename, checksum) = match (version, env::consts::OS, env::consts::ARCH) {
+            ("8.12.0", "darwin", "arm64") => (
+                "gitleaks-8.12.0-darwin-arm64",
+                "da4e64fe24d2ed41e2472f67acdedbf6adadf8e6c7620ce037dc61d7b85859a7",
+            ),
+            ("8.12.0", "darwin", "x86_64") => (
+                "gitleaks-8.12.0-darwin-x86_64",
+                "708de7052fb76a2e61273d0b6210e717a3fac85e955ec1163d17e6bfe864fbfd",
+            ),
             ("8.12.0", "linux", "x86_64") => (
                 "gitleaks-8.12.0-linux-x86_64",
                 "9ed4271ffbfa04feec1423eb56154ad22c11ac4cae698f0115c1a064d4553524",
             ),
-            // Add more supported versions here
+            ("8.12.0", "windows", "x86_64") => (
+                "gitleaks-8.12.0-windows-x86_64.exe",
+                "d7a49162a15133958d3e4b8c0967581fe3069e81847978ad5b5f6903a9f6fa88",
+            ),
             _ => ("gitleaks-unknown-unknown-unknown", "UNSUPPORTED"),
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,8 +47,8 @@ impl Default for GitleaksConfig {
                 "9ed4271ffbfa04feec1423eb56154ad22c11ac4cae698f0115c1a064d4553524",
             ),
             ("8.12.0", "windows", "x86_64") => (
-                "gitleaks-8.16.1-windows-x86_64.exe",
-                "9cfad211670cbfd8550b7512a145d9b1b9276ea6ec3fafb990218b6c0716f512",
+                "gitleaks-8.12.0-windows-x86_64.exe",
+                "d7a49162a15133958d3e4b8c0967581fe3069e81847978ad5b5f6903a9f6fa88  ",
             ),
             _ => ("gitleaks-unknown-unknown-unknown", "UNSUPPORTED"),
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,7 @@ impl Default for GitleaksConfig {
             ),
             ("8.12.0", "windows", "x86_64") => (
                 "gitleaks-8.12.0-windows-x86_64.exe",
-                "d7a49162a15133958d3e4b8c0967581fe3069e81847978ad5b5f6903a9f6fa88  ",
+                "d7a49162a15133958d3e4b8c0967581fe3069e81847978ad5b5f6903a9f6fa88",
             ),
             _ => ("gitleaks-unknown-unknown-unknown", "UNSUPPORTED"),
         };

--- a/src/scanner/gitleaks/config.rs
+++ b/src/scanner/gitleaks/config.rs
@@ -97,7 +97,7 @@ impl RestrictedConfig {
 
 #[derive(Debug, Serialize)]
 pub struct GitleaksRepoConfig {
-    extends: Extends,
+    extend: Extends,
     allowlist: Option<Allowlist>,
 }
 
@@ -109,7 +109,7 @@ impl GitleaksRepoConfig {
         let restricted_config = RestrictedConfig::load_file(repo_gitleaks_toml_path)?;
         let repo_config = Self {
             allowlist: restricted_config.allowlist,
-            extends: Extends {
+            extend: Extends {
                 path: global_config_path.display().to_string(),
             },
         };

--- a/src/scanner/gitleaks/config.rs
+++ b/src/scanner/gitleaks/config.rs
@@ -23,7 +23,7 @@ pub enum ConfigError {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct Extends {
+struct Extend {
     path: String,
 }
 
@@ -85,7 +85,7 @@ impl RestrictedConfig {
 /// `{workspace.config_dir}/gitleaks.toml` that looks something like:
 ///
 /// ```toml
-/// [extends]
+/// [extend]
 /// path = "/path/to/global/config/from/the/pattern/server.toml"
 ///
 /// [allowlist]
@@ -97,7 +97,7 @@ impl RestrictedConfig {
 
 #[derive(Debug, Serialize)]
 pub struct GitleaksRepoConfig {
-    extend: Extends,
+    extend: Extend,
     allowlist: Option<Allowlist>,
 }
 
@@ -109,7 +109,7 @@ impl GitleaksRepoConfig {
         let restricted_config = RestrictedConfig::load_file(repo_gitleaks_toml_path)?;
         let repo_config = Self {
             allowlist: restricted_config.allowlist,
-            extend: Extends {
+            extend: Extend {
                 path: global_config_path.display().to_string(),
             },
         };

--- a/src/scanner/gitleaks/mod.rs
+++ b/src/scanner/gitleaks/mod.rs
@@ -1,6 +1,7 @@
 mod config;
 
 use std::fs;
+use std::fs::File;
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -180,6 +181,7 @@ impl<'g> Gitleaks<'g> {
         let repo_config_path = workspace.config_dir.join("gitleaks.toml");
 
         fs::create_dir_all(&workspace.config_dir)?;
+        fs::create_dir_all(&workspace.results_dir)?;
         fs::write(&repo_config_path, toml::to_string(&repo_config)?)?;
 
         Ok(repo_config_path)
@@ -207,7 +209,7 @@ impl<'g> Gitleaks<'g> {
         let gitleaks_path = self.gitleaks_path()?;
         let staged = options.staged.unwrap_or(false);
         let uncommitted = options.uncommitted.unwrap_or(staged);
-        let report_path = scan_dir.join("gitleaks-results.json");
+        let report_path = workspace.results_dir.join("gitleaks-results.json");
 
         let mut args = vec![
             "--report-path".to_string(),


### PR DESCRIPTION
Windows does not have stdout, which it was using.

Output to a file `gitleaks-results.json` in the scan dir. This made the most sense as it is removed after scanning any way and very very unlikely to have a name clash. If it does clash it is written after the scan is performed and will be overwritten with valid scan result data.

Scan results are cleaned after the scan is complete and results have been consumed.

Also added a few more defaults to make testing defaults across platforms easier.