### PR TITLE
Fixing tests cross platform

### DIFF
--- a/pkg/resource/json_data_test.go
+++ b/pkg/resource/json_data_test.go
@@ -31,31 +31,31 @@ func TestJSONData(t *testing.T) {
 			err:   false,
 		},
 		{
-			path:  filepath.Join("/", "baz", "0"),
+			path:  filepath.Join("baz", "0"),
 			value: "bop",
 			err:   false,
 		},
 		{
-			path:  filepath.Join("/baz", "1"),
+			path:  filepath.Join("baz", "1"),
 			value: "true",
 			err:   false,
 		},
 		{
-			path:  filepath.Join("/baz", "2"),
+			path:  filepath.Join("baz", "2"),
 			value: "1",
 			err:   false,
 		},
 		{
-			path:  filepath.Join("/baz", "3"),
+			path:  filepath.Join("baz", "3"),
 			value: "2.3",
 			err:   false,
 		},
 		{
-			path:  filepath.Join("/baz", "4"),
+			path:  filepath.Join("baz", "4"),
 			value: "",
 			err:   false,
 		}, {
-			path:  filepath.Join("/baz", "5", "hello"),
+			path:  filepath.Join("baz", "5", "hello"),
 			value: "there",
 			err:   false,
 		},

--- a/pkg/scanner/patterns.go
+++ b/pkg/scanner/patterns.go
@@ -88,7 +88,7 @@ func (p *Patterns) gitleaksConfigModTimeExceeds(modTimeLimit uint32) bool {
 
 // Gitleaks returns a Gitleaks config object if it's able to
 func (p *Patterns) Gitleaks() (*gitleaksconfig.Config, error) {
-	// Lock since this this updates the value of p.gitleaksConfig on the fly
+	// Lock since this updates the value of p.gitleaksConfig on the fly
 	// and updates files on the filesystem
 	p.mutex.Lock()
 	defer p.mutex.Unlock()

--- a/pkg/scanner/patterns_test.go
+++ b/pkg/scanner/patterns_test.go
@@ -152,7 +152,7 @@ func TestGitleaksConfigModTimeExceeds(t *testing.T) {
 	t.Run("FileExistsButErrorOnStat", func(t *testing.T) {
 		// Create a Patterns instance with a file path that causes an error on Stat
 		cfg := config.DefaultConfig()
-		cfg.Scanner.Patterns.Gitleaks.ConfigPath = "/dev/null"
+		cfg.Scanner.Patterns.Gitleaks.ConfigPath = "/dev/zero"
 
 		patterns := &Patterns{
 			config: &cfg.Scanner.Patterns,


### PR DESCRIPTION
Making sure tests work on all major platforms:

- Some json tests had a / at the beginning that was breaking on Windows
- MacOS updates the modtime on `/dev/null` it is not the boot time like it is in Linux. Changed this to `/dev/zero` which works. Though the test name is a little confusing because it doesn't fall on stat on Linux or Mac it is just that on Linux boot time is so long ago it work. 

Checked as I merged actions direct to main, tests on Mac, Windows and Linux worked as seen below. 