### PR TITLE
Check branch before cloning

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: '1.20'
+  GO_VERSION: '1.21'
   GO111MODULE: on
 
 on:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/leaktk/scanner
 
-go 1.20
+go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -19,12 +19,14 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/fatih/semgroup v1.2.0 h1:h/OLXwEM+3NNyAdZEpMiH1OzfplU09i2qXPVThGZvyg=
 github.com/fatih/semgroup v1.2.0/go.mod h1:1KAD4iIYfXjE4U13B48VM4z9QUwV5Tt8O4rS879kgm8=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gitleaks/go-gitdiff v0.9.0 h1:SHAU2l0ZBEo8g82EeFewhVy81sb7JCxW76oSPtR/Nqg=
 github.com/gitleaks/go-gitdiff v0.9.0/go.mod h1:pKz0X4YzCKZs30BL+weqBIG7mx0jl4tF1uXV9ZyNvrA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
@@ -35,9 +37,11 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -64,6 +68,7 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/pkg/resource/git.go
+++ b/pkg/resource/git.go
@@ -27,12 +27,6 @@ func init() {
 	}
 }
 
-// remoteRefExists checks a remote git repository to make sure the ref exists
-func remoteRefExists(url, ref string) bool {
-	cmd := exec.Command("git", "ls-remote", "--exit-code", "--quiet", url, ref)
-	return cmd.Run() == nil
-}
-
 // GitRepoOptions stores options specific to GitRepo scan requests
 type GitRepoOptions struct {
 	// Only scan this branch
@@ -88,7 +82,7 @@ func (r *GitRepo) Clone(path string) error {
 	// The --[no-]single-branch flags are still needed with mirror due to how
 	// things like --depth and --shallow-since behave
 	if len(r.options.Branch) > 0 {
-		if remoteRefExists(r.String(), r.options.Branch) {
+		if r.RemoteRefExists(r.options.Branch) {
 			cloneArgs = append(cloneArgs, "--single-branch")
 			cloneArgs = append(cloneArgs, "--branch")
 			cloneArgs = append(cloneArgs, r.options.Branch)
@@ -228,6 +222,12 @@ func (r *GitRepo) Walk(fn WalkFunc) error {
 	}
 
 	return nil
+}
+
+// RemoteRefExists checks the remote repository to see if the ref exists
+func (r *GitRepo) RemoteRefExists(ref string) bool {
+	cmd := exec.Command("git", "ls-remote", "--exit-code", "--quiet", r.String(), ref) // #nosec G204
+	return cmd.Run() == nil
 }
 
 // Refs returns the unique OIDs in a repo

--- a/pkg/resource/git.go
+++ b/pkg/resource/git.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -24,6 +25,12 @@ func init() {
 	if err := os.Setenv("GIT_NO_REPLACE_OBJECTS", "1"); err != nil {
 		logger.Error("could not set GIT_NO_REPLACE_OBJECTS=1: error=%q", err)
 	}
+}
+
+// remoteRefExists checks a remote git repository to make sure the ref exists
+func remoteRefExists(url, ref string) bool {
+	cmd := exec.Command("git", "ls-remote", "--exit-code", "--quiet", url, ref)
+	return cmd.Run() == nil
 }
 
 // GitRepoOptions stores options specific to GitRepo scan requests
@@ -81,9 +88,14 @@ func (r *GitRepo) Clone(path string) error {
 	// The --[no-]single-branch flags are still needed with mirror due to how
 	// things like --depth and --shallow-since behave
 	if len(r.options.Branch) > 0 {
-		cloneArgs = append(cloneArgs, "--single-branch")
-		cloneArgs = append(cloneArgs, "--branch")
-		cloneArgs = append(cloneArgs, r.options.Branch)
+		if remoteRefExists(r.String(), r.options.Branch) {
+			cloneArgs = append(cloneArgs, "--single-branch")
+			cloneArgs = append(cloneArgs, "--branch")
+			cloneArgs = append(cloneArgs, r.options.Branch)
+		} else {
+			logger.Warning("ignoring invalid branch: branch=%q", r.options.Branch)
+			cloneArgs = append(cloneArgs, "--no-single-branch")
+		}
 	} else {
 		cloneArgs = append(cloneArgs, "--no-single-branch")
 	}
@@ -216,4 +228,30 @@ func (r *GitRepo) Walk(fn WalkFunc) error {
 	}
 
 	return nil
+}
+
+// Refs returns the unique OIDs in a repo
+func (r *GitRepo) Refs() []string {
+	cmd := exec.Command("git", "-C", r.ClonePath(), "show-ref", "--hash") // #nosec G204
+	out, err := cmd.Output()
+	refs := []string{}
+
+	if err != nil {
+		logger.Error("could not list refs: error=%q", err)
+		return refs
+	}
+
+	for _, ref := range bytes.Split(out, []byte{'\n'}) {
+		refStr := strings.TrimSpace(string(ref))
+
+		if len(refStr) == 0 {
+			continue
+		}
+
+		if !slices.Contains(refs, refStr) {
+			refs = append(refs, refStr)
+		}
+	}
+
+	return refs
 }

--- a/pkg/resource/git_test.go
+++ b/pkg/resource/git_test.go
@@ -1,0 +1,50 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGit(t *testing.T) {
+	t.Run("BranchNotProvied", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		gitRepo := NewGitRepo("https://github.com/leaktk/fake-leaks.git", &GitRepoOptions{
+			Depth: 1,
+		})
+
+		err := gitRepo.Clone(tempDir)
+		assert.NoError(t, err)
+		assert.Greater(t, len(gitRepo.Refs()), 1)
+	})
+
+	t.Run("BranchProvied", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		gitRepo := NewGitRepo("https://github.com/leaktk/fake-leaks.git", &GitRepoOptions{
+			Branch: "main",
+			Depth:  1,
+		})
+
+		err := gitRepo.Clone(tempDir)
+		assert.NoError(t, err)
+		assert.Equal(t, len(gitRepo.Refs()), 1)
+	})
+
+	t.Run("BranchInvalid", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		gitRepo := NewGitRepo("https://github.com/leaktk/fake-leaks.git", &GitRepoOptions{
+			Branch: "invalid-branch-e7d33d3a-6057-432a-863b-0ed844ee1f7b",
+			Depth:  1,
+		})
+
+		err := gitRepo.Clone(tempDir)
+		assert.NoError(t, err)
+		// Should increase the scope of the clone to be the same as if no branch
+		// was provided
+		assert.Greater(t, len(gitRepo.Refs()), 1)
+	})
+
+}


### PR DESCRIPTION
If the branch doesn't exist on the remote, expand the scan scope to all branches.