### PR TITLE
Fix panic on invalid remote gitleaks.toml

### DIFF
--- a/pkg/scanner/gitleaks.go
+++ b/pkg/scanner/gitleaks.go
@@ -74,7 +74,7 @@ func (g *Gitleaks) newDetector(scanResource resource.Resource) (*detect.Detector
 	if err == nil {
 		clonedConfig, err := ParseGitleaksConfig(string(rawClonedConfig))
 
-		if err != nil {
+		if err != nil || clonedConfig == nil {
 			logger.Error("could not load cloned .gitleaks.toml: resource_id=%q error=%q", scanResource.ID(), err)
 		} else {
 			logger.Debug("loading cloned .gitleaks.toml")

--- a/pkg/scanner/gitleaks.go
+++ b/pkg/scanner/gitleaks.go
@@ -74,7 +74,7 @@ func (g *Gitleaks) newDetector(scanResource resource.Resource) (*detect.Detector
 	if err == nil {
 		clonedConfig, err := ParseGitleaksConfig(string(rawClonedConfig))
 
-		if err != nil || clonedConfig == nil {
+		if err != nil {
 			logger.Error("could not load cloned .gitleaks.toml: resource_id=%q error=%q", scanResource.ID(), err)
 		} else {
 			logger.Debug("loading cloned .gitleaks.toml")

--- a/pkg/scanner/patterns.go
+++ b/pkg/scanner/patterns.go
@@ -151,16 +151,16 @@ func invalidConfig(cfg *gitleaksconfig.Config) bool {
 }
 
 // ParseGitleaksConfig takes a gitleaks config string and returns a config object
-func ParseGitleaksConfig(rawConfig string) (*gitleaksconfig.Config, error) {
+func ParseGitleaksConfig(rawConfig string) (glc *gitleaksconfig.Config, err error) {
 	var vc gitleaksconfig.ViperConfig
 
 	defer func() {
-		if recover() != nil {
-			logger.Error("Gitleaks config is invalid. Recovering")
+		if r := recover(); r != nil {
+			err = fmt.Errorf("gitleaks config is invalid: error=%q", r)
 		}
 	}()
 
-	_, err := toml.Decode(rawConfig, &vc)
+	_, err = toml.Decode(rawConfig, &vc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scanner/patterns.go
+++ b/pkg/scanner/patterns.go
@@ -154,6 +154,12 @@ func invalidConfig(cfg *gitleaksconfig.Config) bool {
 func ParseGitleaksConfig(rawConfig string) (*gitleaksconfig.Config, error) {
 	var vc gitleaksconfig.ViperConfig
 
+	defer func() {
+		if recover() != nil {
+			logger.Error("Gitleaks config is invalid. Recovering")
+		}
+	}()
+
 	_, err := toml.Decode(rawConfig, &vc)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If the regex inside a gitleak toml file is invalid it will cause a panic.

This code adds a `recover` and allows the main process and other routines to continue. It bails out of the rest of the ParseGitleaksConfig, hence having to add a check for a nil config.