### PR TITLE
logs should use the requesters id

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -142,7 +142,7 @@ func (s *Scanner) listenForScanRequests() {
 				}
 			}
 			if err := s.removeResourceFiles(reqResource); err != nil {
-				logger.Error("resource file cleanup error: resource_id=%q error=%q", request.ID, err.Error())
+				logger.Error("resource file cleanup error: request_id=%q error=%q", request.ID, err.Error())
 			}
 		} else {
 			logger.Error("skipping scan due to missing clone path: resource_id=%q", request.ID)

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -97,7 +97,7 @@ func (s *Scanner) listenForCloneRequests() {
 		}
 
 		if reqResource.ClonePath() == "" {
-			logger.Info("starting clone: reqsource_id=%q", request.ID)
+			logger.Info("starting clone: request_id=%q", request.ID)
 			if err := reqResource.Clone(s.resourceClonePath(reqResource)); err != nil {
 				logger.Error("clone error: resource_id=%q error=%q", request.ID, err.Error())
 			}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -135,7 +135,7 @@ func (s *Scanner) listenForScanRequests() {
 
 				backendResults, err := backend.Scan(reqResource)
 				if err != nil {
-					logger.Error("scan error: resource_id=%q error=%q", request.ID, err.Error())
+					logger.Error("scan error: request_id=%q error=%q", request.ID, err.Error())
 				}
 				if backendResults != nil {
 					results = append(results, backendResults...)

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -92,14 +92,14 @@ func (s *Scanner) listenForCloneRequests() {
 		}
 
 		if s.maxScanDepth > 0 && reqResource.Depth() > s.maxScanDepth {
-			logger.Warning("reducing scan depth: resource_id=%q old_depth=%v new_depth=%v", reqResource.ID(), reqResource.Depth(), s.maxScanDepth)
+			logger.Warning("reducing scan depth: resource_id=%q old_depth=%v new_depth=%v", request.ID, reqResource.Depth(), s.maxScanDepth)
 			reqResource.SetDepth(s.maxScanDepth)
 		}
 
 		if reqResource.ClonePath() == "" {
-			logger.Info("starting clone: reqsource_id=%q", reqResource.ID())
+			logger.Info("starting clone: reqsource_id=%q", request.ID)
 			if err := reqResource.Clone(s.resourceClonePath(reqResource)); err != nil {
-				logger.Error("clone error: resource_id=%q error=%q", reqResource.ID(), err.Error())
+				logger.Error("clone error: resource_id=%q error=%q", request.ID, err.Error())
 			}
 		}
 
@@ -131,21 +131,21 @@ func (s *Scanner) listenForScanRequests() {
 
 		if fs.PathExists(reqResource.ClonePath()) {
 			for _, backend := range s.backends {
-				logger.Info("starting scan: reqsource_id=%q scanner_backend=%q", reqResource.ID(), backend.Name())
+				logger.Info("starting scan: reqsource_id=%q scanner_backend=%q", request.ID, backend.Name())
 
 				backendResults, err := backend.Scan(reqResource)
 				if err != nil {
-					logger.Error("scan error: resource_id=%q error=%q", reqResource.ID(), err.Error())
+					logger.Error("scan error: resource_id=%q error=%q", request.ID, err.Error())
 				}
 				if backendResults != nil {
 					results = append(results, backendResults...)
 				}
 			}
 			if err := s.removeResourceFiles(reqResource); err != nil {
-				logger.Error("resource file cleanup error: resource_id=%q error=%q", reqResource.ID(), err.Error())
+				logger.Error("resource file cleanup error: resource_id=%q error=%q", request.ID, err.Error())
 			}
 		} else {
-			logger.Error("skipping scan due to missing clone path: resource_id=%q", reqResource.ID())
+			logger.Error("skipping scan due to missing clone path: resource_id=%q", request.ID)
 		}
 
 		s.responses <- &Response{

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -145,7 +145,7 @@ func (s *Scanner) listenForScanRequests() {
 				logger.Error("resource file cleanup error: request_id=%q error=%q", request.ID, err.Error())
 			}
 		} else {
-			logger.Error("skipping scan due to missing clone path: resource_id=%q", request.ID)
+			logger.Error("skipping scan due to missing clone path: request_id=%q", request.ID)
 		}
 
 		s.responses <- &Response{

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -92,7 +92,7 @@ func (s *Scanner) listenForCloneRequests() {
 		}
 
 		if s.maxScanDepth > 0 && reqResource.Depth() > s.maxScanDepth {
-			logger.Warning("reducing scan depth: resource_id=%q old_depth=%v new_depth=%v", request.ID, reqResource.Depth(), s.maxScanDepth)
+			logger.Warning("reducing scan depth: request_id=%q old_depth=%v new_depth=%v", request.ID, reqResource.Depth(), s.maxScanDepth)
 			reqResource.SetDepth(s.maxScanDepth)
 		}
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -131,7 +131,7 @@ func (s *Scanner) listenForScanRequests() {
 
 		if fs.PathExists(reqResource.ClonePath()) {
 			for _, backend := range s.backends {
-				logger.Info("starting scan: reqsource_id=%q scanner_backend=%q", request.ID, backend.Name())
+				logger.Info("starting scan: request_id=%q scanner_backend=%q", request.ID, backend.Name())
 
 				backendResults, err := backend.Scan(reqResource)
 				if err != nil {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -99,7 +99,7 @@ func (s *Scanner) listenForCloneRequests() {
 		if reqResource.ClonePath() == "" {
 			logger.Info("starting clone: request_id=%q", request.ID)
 			if err := reqResource.Clone(s.resourceClonePath(reqResource)); err != nil {
-				logger.Error("clone error: resource_id=%q error=%q", request.ID, err.Error())
+				logger.Error("clone error: request_id=%q error=%q", request.ID, err.Error())
 			}
 		}
 


### PR DESCRIPTION
Providing the users request id makes it a lot easier for the user to tie together messages other than the final results, which is the only one that includes the original request id.