### PR TITLE
Bundle major errors into Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ clone.
     "kind": "GitRepo",
     "resource": "http://github.com/leaktk/fake-leaks.git"
   },
+  "errors": [],
   "results": [
     {
       "id": "c80efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7",
@@ -210,6 +211,7 @@ example of including a `.gitleaks.toml` with a JSONData scan.
     "kind": "JSONData",
     "resource": "{\"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}"
   },
+  "errors": [],
   "results": [
     {
       "id": "66456b43e1efac03f9448ece59a65b0e2bf304b55506507a8aa07727e3900522",
@@ -283,6 +285,7 @@ Files currently doesn't have any options but all the Gitleaks config files
     "kind": "Files",
     "resource": "/path/to/fake-leaks/keys/tls"
   },
+  "errors": [],
   "results": [
     {
       "id": "9376e604a7e8c4f5259ceb47f8a29c57e77c07668e317fa8c177de5e56fbe029",
@@ -356,6 +359,7 @@ URL currently doesn't have any options.
     "kind": "URL",
     "resource": "https://raw.githubusercontent.com/leaktk/fake-leaks/main/keys/tls/server.key"
   },
+  "errors": [],
   "results": [
     {
       "id": "6c14f496a2111dfeecbfff4a61587b0b1866788a6112b420f80071f8cded0153",

--- a/pkg/scanner/error.go
+++ b/pkg/scanner/error.go
@@ -1,0 +1,32 @@
+package scanner
+
+import "fmt"
+
+type LeakTKError struct {
+	Fatal   bool      `json:"fatal"`
+	Code    ErrorCode `json:"code"`
+	Message string    `json:"message"`
+}
+
+func (e LeakTKError) Error() string {
+	return e.String()
+}
+
+func (e LeakTKError) String() string {
+	fatal := ""
+	if e.Fatal {
+		fatal = "fatal "
+	}
+	return fmt.Sprintf("%serror occured, code %d (%s): %s", fatal, e.Code, errorNames[e.Code], e.Message)
+}
+
+type ErrorCode int
+
+const (
+	NoError = iota
+	CloneError
+	ScanError
+	ResourceCleanupError
+)
+
+var errorNames = [...]string{"NoError", "CloneError", "ScanError", "ResourceCleanupError"}

--- a/pkg/scanner/error_test.go
+++ b/pkg/scanner/error_test.go
@@ -1,0 +1,22 @@
+package scanner
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestL(t *testing.T) {
+	e := LeakTKError{
+		Fatal:   false,
+		Code:    2,
+		Message: "test error message",
+	}
+	t.Run("non fatal output", func(t *testing.T) {
+		assert.Equal(t, "error occured, code 2 (ScanError): test error message", e.String())
+	})
+
+	e.Fatal = true
+	t.Run("fatal output", func(t *testing.T) {
+		assert.Equal(t, "fatal error occured, code 2 (ScanError): test error message", e.String())
+	})
+}

--- a/pkg/scanner/request.go
+++ b/pkg/scanner/request.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"github.com/leaktk/scanner/pkg/logger"
 	"github.com/leaktk/scanner/pkg/resource"
 )
@@ -14,6 +13,7 @@ type Request struct {
 	ID string
 	// Thing to scan (e.g. URL, snippet of text, etc)
 	Resource resource.Resource
+	Errors   []LeakTKError
 }
 
 // UnmarshalJSON sets r to a copy of data

--- a/pkg/scanner/response.go
+++ b/pkg/scanner/response.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
 	"encoding/json"
-
 	"github.com/leaktk/scanner/pkg/logger"
 )
 
@@ -18,6 +17,7 @@ type (
 	// Response from the scanner with the scan results
 	Response struct {
 		ID      string         `json:"id"`
+		Errors  []LeakTKError  `json:"errors"`
 		Request RequestDetails `json:"request"`
 		Results []*Result      `json:"results"`
 	}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -168,9 +168,6 @@ func (s *Scanner) listenForScanRequests() {
 				Message: fmt.Sprintf("missing clone path: request_id=%q (%s)", request.ID, reqResource.ClonePath()),
 			})
 		}
-		for _, e := range request.Errors {
-			fmt.Println(e)
-		}
 		s.responses <- &Response{
 			ID:      id.ID(),
 			Results: results,


### PR DESCRIPTION
This feature is a must, it makes it much easier for other systems consuming the output to tie together errors with responses.

The implementation 🤷 . This only covers major errors, only the ones that are currently tied to request id's already. We could add further to error holding to the resource. This could help if we want to know whether the local .gitleaks.toml files failed or other similar errors. 