### PR TITLE
Calculate & log the sha256 hash of patterns on update

### DIFF
--- a/pkg/scanner/patterns.go
+++ b/pkg/scanner/patterns.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,10 +21,11 @@ import (
 // Patterns acts as an abstraction for fetching different scanner patterns
 // and keeping them up to date and cached
 type Patterns struct {
-	client         HTTPClient
-	config         *config.Patterns
-	gitleaksConfig *gitleaksconfig.Config
-	mutex          sync.Mutex
+	client             HTTPClient
+	config             *config.Patterns
+	gitleaksConfigHash [32]byte
+	gitleaksConfig     *gitleaksconfig.Config
+	mutex              sync.Mutex
 }
 
 // NewPatterns returns a configured instance of Patterns
@@ -95,7 +97,6 @@ func (p *Patterns) Gitleaks() (*gitleaksconfig.Config, error) {
 
 	if p.config.Autofetch && p.gitleaksConfigModTimeExceeds(p.config.RefreshAfter) {
 		rawConfig, err := p.fetchGitleaksConfig()
-
 		if err != nil {
 			return p.gitleaksConfig, err
 		}
@@ -115,6 +116,7 @@ func (p *Patterns) Gitleaks() (*gitleaksconfig.Config, error) {
 		if err := os.WriteFile(p.config.Gitleaks.ConfigPath, []byte(rawConfig), 0600); err != nil {
 			return p.gitleaksConfig, fmt.Errorf("could not write config: path=%q error=%q", p.config.Gitleaks.ConfigPath, err)
 		}
+		p.gitleaksConfigHash = sha256.Sum256([]byte(rawConfig))
 	} else if p.gitleaksConfig == nil {
 		if p.gitleaksConfigModTimeExceeds(p.config.ExpiredAfter) {
 			return nil, fmt.Errorf(
@@ -133,9 +135,16 @@ func (p *Patterns) Gitleaks() (*gitleaksconfig.Config, error) {
 			logger.Debug("loaded config:\n%s\n", rawConfig)
 			return p.gitleaksConfig, fmt.Errorf("could not parse config: error=%q", err)
 		}
+		p.gitleaksConfigHash = sha256.Sum256(rawConfig)
 	}
+	logger.Info("updated gitleaks patterns: hash=%s", p.GitleaksConfigHash())
 
 	return p.gitleaksConfig, nil
+}
+
+// GitleaksConfigHash returns the sha256 hash for the current gitleaks config
+func (p *Patterns) GitleaksConfigHash() string {
+	return fmt.Sprintf("%x", p.gitleaksConfigHash)
 }
 
 func invalidConfig(cfg *gitleaksconfig.Config) bool {


### PR DESCRIPTION
For our use case we would like to know when the patterns have changed so that we can extend our look-back and re-scan some repositories that have already been scanned with the previous patterns. 
This change calculates the sha256 hash of the patterns on loading and after each refresh - sending this out as part of a logger.Info message.