### PR TITLE
Fix git log failing on invalid objects

### DIFF
--- a/pkg/scanner/error.go
+++ b/pkg/scanner/error.go
@@ -22,7 +22,7 @@ func (e LeakTKError) String() string {
 		fatal = "fatal "
 	}
 
-	return fmt.Sprintf("%serror occured, code %d (%s): %s", fatal, e.Code, errorNames[e.Code], e.Message)
+	return fmt.Sprintf("%serror occurred, code %d (%s): %s", fatal, e.Code, errorNames[e.Code], e.Message)
 }
 
 // ErrorCode defined sthe set of error codes that can be set on a LeakTKError

--- a/pkg/scanner/error_test.go
+++ b/pkg/scanner/error_test.go
@@ -12,11 +12,11 @@ func TestL(t *testing.T) {
 		Message: "test error message",
 	}
 	t.Run("non fatal output", func(t *testing.T) {
-		assert.Equal(t, "error occured, code 2 (ScanError): test error message", e.String())
+		assert.Equal(t, "error occurred, code 2 (ScanError): test error message", e.String())
 	})
 
 	e.Fatal = true
 	t.Run("fatal output", func(t *testing.T) {
-		assert.Equal(t, "fatal error occured, code 2 (ScanError): test error message", e.String())
+		assert.Equal(t, "fatal error occurred, code 2 (ScanError): test error message", e.String())
 	})
 }

--- a/pkg/scanner/gitleaks.go
+++ b/pkg/scanner/gitleaks.go
@@ -91,7 +91,7 @@ func (g *Gitleaks) newDetector(scanResource resource.Resource) (*detect.Detector
 
 // gitScan handles when the resource is a gitRepo type
 func (g *Gitleaks) gitScan(detector *detect.Detector, gitRepo *resource.GitRepo) ([]report.Finding, error) {
-	gitLogOpts := []string{"--full-history", "--all"}
+	gitLogOpts := []string{"--full-history", "--all", "--ignore-missing"}
 
 	if len(gitRepo.Since()) > 0 {
 		gitLogOpts = append(gitLogOpts, "--since")


### PR DESCRIPTION
When doing a shallow commit there is a list of hashes in the shallow file. Sometimes these are invalid. We want to not include the list of hashes in this list otherwise we will end up including secrets included before the shallow commit. This is more likely to happen on busy repositories.

The change here allows us to skip and invalid hashes (likely commits in branches that have since been squashed/deleted).

Added a fix for a spelling error as well.