### PR TITLE
Log when a URL fetch in JSONData fails rather than failing the whole scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,3 +426,6 @@ use the same logic as `JSONData` when the response's content type is
 1. Figure out a way to apply different rules in different contexts (internal/external repos, etc)
 1. Support `.github/secret_scanning.yml` files
 1. Have options for URL and JSONData to allow them to recursively pull other URLs when they see them (e.g. `follow_urls bool`, `depth uint16`) and make sure it can't loop
+1. Improve error handling, allowing resources to better handle fatal/nonfatal errors
+1. Implement scanning with Yara
+1. Investigate a custom log handler to consume the logs from the embedded gitleaks. Log to DEBUG.

--- a/pkg/resource/json_data.go
+++ b/pkg/resource/json_data.go
@@ -112,7 +112,10 @@ func (r *JSONData) fetchURLs(rootNode jsonNode, clonePath string) error {
 		err := urlResource.Clone(filepath.Join(clonePath, leafNode.path))
 
 		if err != nil {
-			return fmt.Errorf("could not fetch url: path=%q url=%q error=%q", leafNode.path, obj, err)
+			// Not being able to retrieve a URL found inside JSONData is not a fatal error. Logging until update how
+			// we manage fatal/nonfatal errors flowing through the application.
+			logger.Info("%v", fmt.Errorf("could not fetch url: path=%q url=%q error=%q", leafNode.path, obj, err))
+			return nil
 		}
 
 		return r.replaceWithResource(leafNode, urlResource)

--- a/pkg/resource/json_data_test.go
+++ b/pkg/resource/json_data_test.go
@@ -189,12 +189,13 @@ func TestJSONData(t *testing.T) {
 		assert.NoError(t, jsonData.Clone(t.TempDir()))
 	})
 
-	t.Run("CloneBrokenURLWithFetchURLs", func(t *testing.T) {
-		// Should throw an error
-		jsonData := NewJSONData(brokenURLData, &JSONDataOptions{
-			FetchURLs: true,
-		})
-
-		assert.Error(t, jsonData.Clone(t.TempDir()))
-	})
+	// Removing this test until we fix up error handling. Broken URLs is not a fatal error.
+	//t.Run("CloneBrokenURLWithFetchURLs", func(t *testing.T) {
+	//	// Should throw an error
+	//	jsonData := NewJSONData(brokenURLData, &JSONDataOptions{
+	//		FetchURLs: true,
+	//	})
+	//
+	//	assert.Error(t, jsonData.Clone(t.TempDir()))
+	//})
 }


### PR DESCRIPTION
The change is small,  instead of passing the error up, which would cause the clone to fail and the JSONData to not be scanned. This logs that a URL was unable to be fetched, passing back no error and allowing scanning to continue.

This is a short term solution until we improve our general error handling. Allowing fatal/nonfatal errors to be floated up to the application.

Added a few items to the to do list, including the aforementioned error handling.