### PR TITLE
Only return request_id, not the whole request.

### DIFF
--- a/pkg/scanner/response.go
+++ b/pkg/scanner/response.go
@@ -16,17 +16,10 @@ const (
 type (
 	// Response from the scanner with the scan results
 	Response struct {
-		ID      string         `json:"id"`
-		Errors  []LeakTKError  `json:"errors"`
-		Request RequestDetails `json:"request"`
-		Results []*Result      `json:"results"`
-	}
-
-	// RequestDetails that we return with the response for tying the two together
-	RequestDetails struct {
-		ID       string `json:"id"`
-		Kind     string `json:"kind"`
-		Resource string `json:"resource"`
+		ID        string        `json:"id"`
+		Errors    []LeakTKError `json:"errors"`
+		RequestID string        `json:"request_id"`
+		Results   []*Result     `json:"results"`
 	}
 
 	// Result of a scan

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -169,14 +169,10 @@ func (s *Scanner) listenForScanRequests() {
 			})
 		}
 		s.responses <- &Response{
-			ID:      id.ID(),
-			Results: results,
-			Errors:  request.Errors,
-			Request: RequestDetails{
-				ID:       request.ID,
-				Kind:     request.Resource.Kind(),
-				Resource: request.Resource.String(),
-			},
+			ID:        id.ID(),
+			Results:   results,
+			Errors:    request.Errors,
+			RequestID: request.ID,
 		}
 	}
 }


### PR DESCRIPTION
The whole request can be quite sizeable, especially with JSONData. The requester should know their unique request ID so can link using only that.