### PR TITLE
Update resource logging in responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Sets the request priority. Higher priority items will be scanned first.
     "kind": "GitRepo",
     "resource": "http://github.com/leaktk/fake-leaks.git"
   },
-  "errors": [],
+  "logs": [],
   "results": [
     {
       "id": "c80efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7",
@@ -237,7 +237,7 @@ Sets the request priority. Higher priority items will be scanned first.
     "kind": "JSONData",
     "resource": "{\"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}"
   },
-  "errors": [],
+  "logs": [],
   "results": [
     {
       "id": "66456b43e1efac03f9448ece59a65b0e2bf304b55506507a8aa07727e3900522",
@@ -315,7 +315,7 @@ Sets the request priority. Higher priority items will be scanned first.
     "kind": "Files",
     "resource": "/path/to/fake-leaks/keys/tls"
   },
-  "errors": [],
+  "logs": [],
   "results": [
     {
       "id": "9376e604a7e8c4f5259ceb47f8a29c57e77c07668e317fa8c177de5e56fbe029",
@@ -394,7 +394,7 @@ Sets the request priority. Higher priority items will be scanned first.
     "kind": "URL",
     "resource": "https://raw.githubusercontent.com/leaktk/fake-leaks/main/keys/tls/server.key"
   },
-  "errors": [],
+  "logs": [],
   "results": [
     {
       "id": "6c14f496a2111dfeecbfff4a61587b0b1866788a6112b420f80071f8cded0153",
@@ -551,6 +551,5 @@ so not all images will have the information.
 1. Figure out a way to apply different rules in different contexts (internal/external repos, etc)
 1. Support `.github/secret_scanning.yml` files
 1. Have options for URL and JSONData to allow them to recursively pull other URLs when they see them (e.g. `follow_urls bool`, `depth uint16`) and make sure it can't loop
-1. Improve error handling, allowing resources to better handle fatal/nonfatal errors
 1. Implement scanning with Yara
 1. Investigate a custom log handler to consume the logs from the embedded gitleaks. Log to DEBUG.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -21,7 +21,8 @@ scan_workers = 1
 # The full path to where the scanner should store files, clone repos, etc
 # for better performance mount a tmpfs at this location
 # workdir = "/tmp/leaktk/scanner" # This defaults to ${XDG_CACHE_HOME}/leaktk/scanner
-
+# Include logs at logger level in response
+# include_logs_response = false
 
 [scanner.patterns]
 # Tells the scanner if it can fetch pattenrs or not

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -22,7 +22,7 @@ scan_workers = 1
 # for better performance mount a tmpfs at this location
 # workdir = "/tmp/leaktk/scanner" # This defaults to ${XDG_CACHE_HOME}/leaktk/scanner
 # Include logs at logger level in response
-# include_logs_response = false
+include_response_logs = false
 
 [scanner.patterns]
 # Tells the scanner if it can fetch pattenrs or not

--- a/examples/requests.jsonl
+++ b/examples/requests.jsonl
@@ -12,3 +12,4 @@
 {"id":"324cbaba6d05a483a5501925daa0baf0fdf5cd204aac0af08c86ba661afeef2f", "kind":"ContainerImage","resource":"quay.io/jetstack/cert-manager-controller:v1.16.0"}
 {"kind": "GitRepo", "id": "low-priority", "resource": "https://github.com/leaktk/fake-leaks", "options": {"priority": 0}}
 {"kind": "GitRepo", "id": "high-priority", "resource": "https://github.com/leaktk/fake-leaks", "options": {"priority": 1}}
+{"id":"580efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"JSONData", "resource":"{\"url1\":\"https://notreal.co.asd\", \"url2\":\"http://www.google.com\", \"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}", "options": {"fetch_urls": "*"}}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,12 +30,13 @@ type (
 
 	// Scanner provides scanner specific config
 	Scanner struct {
-		CloneTimeout uint16   `toml:"clone_timeout"`
-		CloneWorkers uint16   `toml:"clone_workers"`
-		MaxScanDepth uint16   `toml:"max_scan_depth"`
-		Patterns     Patterns `toml:"patterns"`
-		ScanWorkers  uint16   `toml:"scan_workers"`
-		Workdir      string   `toml:"workdir"`
+		CloneTimeout        uint16   `toml:"clone_timeout"`
+		CloneWorkers        uint16   `toml:"clone_workers"`
+		IncludeResponseLogs bool     `toml:"include_logs_response"`
+		MaxScanDepth        uint16   `toml:"max_scan_depth"`
+		Patterns            Patterns `toml:"patterns"`
+		ScanWorkers         uint16   `toml:"scan_workers"`
+		Workdir             string   `toml:"workdir"`
 	}
 
 	// Patterns provides configuration for managing pattern updates
@@ -172,11 +173,12 @@ func DefaultConfig() *Config {
 			Level: "INFO",
 		},
 		Scanner: Scanner{
-			CloneTimeout: 0,
-			CloneWorkers: 1,
-			MaxScanDepth: 0,
-			ScanWorkers:  1,
-			Workdir:      filepath.Join(leaktkCacheDir(), "scanner"),
+			CloneTimeout:        0,
+			CloneWorkers:        1,
+			IncludeResponseLogs: false,
+			MaxScanDepth:        0,
+			ScanWorkers:         1,
+			Workdir:             filepath.Join(leaktkCacheDir(), "scanner"),
 			Patterns: Patterns{
 				Autofetch:    true,
 				ExpiredAfter: 60 * 60 * 12 * 14, // 7 days

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ type (
 	Scanner struct {
 		CloneTimeout        uint16   `toml:"clone_timeout"`
 		CloneWorkers        uint16   `toml:"clone_workers"`
-		IncludeResponseLogs bool     `toml:"include_response_logs  "`
+		IncludeResponseLogs bool     `toml:"include_response_logs"`
 		MaxScanDepth        uint16   `toml:"max_scan_depth"`
 		Patterns            Patterns `toml:"patterns"`
 		ScanWorkers         uint16   `toml:"scan_workers"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ type (
 	Scanner struct {
 		CloneTimeout        uint16   `toml:"clone_timeout"`
 		CloneWorkers        uint16   `toml:"clone_workers"`
-		IncludeResponseLogs bool     `toml:"include_logs_response"`
+		IncludeResponseLogs bool     `toml:"include_response_logs  "`
 		MaxScanDepth        uint16   `toml:"max_scan_depth"`
 		Patterns            Patterns `toml:"patterns"`
 		ScanWorkers         uint16   `toml:"scan_workers"`

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -42,12 +42,12 @@ const (
 	HUMAN LogFormat = 1
 )
 
-// ErrorCode defined sthe set of error codes that can be set on a Entry
-type ErrorCode int
+// LogCode defines the set of  codes that can be set on an Entry
+type LogCode int
 
 const (
-	// NoErrorCode means the error code hasn't been set
-	NoErrorCode = iota
+	// NoCode means the entry code hasn't been set
+	NoCode = iota
 	// CloneError means we were unable to successfully clone the resource
 	CloneError
 	// ScanError means there was some issue scanning the cloned resource
@@ -58,10 +58,10 @@ const (
 	CommandError
 )
 
-var errorNames = [...]string{"NoErrorCode", "CloneError", "ScanError", "ResourceCleanupError", "CommandError"}
+var logCodeNames = [...]string{"NoCode", "CloneError", "ScanError", "ResourceCleanupError", "CommandError"}
 
-func (code ErrorCode) String() string {
-	return errorNames[code]
+func (code LogCode) String() string {
+	return logCodeNames[code]
 }
 
 // String renders a LogLevel as its string value

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -42,6 +42,28 @@ const (
 	HUMAN LogFormat = 1
 )
 
+// ErrorCode defined sthe set of error codes that can be set on a Entry
+type ErrorCode int
+
+const (
+	// NoErrorCode means the error code hasn't been set
+	NoErrorCode = iota
+	// CloneError means we were unable to successfully clone the resource
+	CloneError
+	// ScanError means there was some issue scanning the cloned resource
+	ScanError
+	// ResourceCleanupError means we couldn't remove the resources that were cloned after a scan
+	ResourceCleanupError
+	// CommandError means there was an error with an external command
+	CommandError
+)
+
+var errorNames = [...]string{"NoErrorCode", "CloneError", "ScanError", "ResourceCleanupError", "CommandError"}
+
+func (code ErrorCode) String() string {
+	return errorNames[code]
+}
+
 // String renders a LogLevel as its string value
 func (l LogLevel) String() string {
 	switch l {
@@ -69,6 +91,7 @@ var currentLogFormat = HUMAN
 type Entry struct {
 	Time     string `json:"time"`
 	Severity string `json:"severity"`
+	Code     string `json:"code,omitempty"`
 	Message  string `json:"message"`
 }
 
@@ -144,55 +167,59 @@ func GetLoggerLevel() LogLevel {
 }
 
 // Debug emits an DEBUG level log
-func Debug(msg string, a ...any) {
+func Debug(msg string, a ...any) *Entry {
 	if currentLogLevel > DEBUG {
-		return
+		return nil
 	}
-
-	log.Println(Entry{
+	entry := Entry{
 		Time:     time.Now().UTC().Format(time.RFC3339),
 		Severity: "DEBUG",
 		Message:  fmt.Sprintf(msg, a...),
-	})
+	}
+	log.Println(entry)
+	return &entry
 }
 
 // Info emits an INFO level log
-func Info(msg string, a ...any) {
+func Info(msg string, a ...any) *Entry {
 	if currentLogLevel > INFO {
-		return
+		return nil
 	}
-
-	log.Println(Entry{
+	entry := Entry{
 		Time:     time.Now().UTC().Format(time.RFC3339),
 		Severity: "INFO",
 		Message:  fmt.Sprintf(msg, a...),
-	})
+	}
+	log.Println(entry)
+	return &entry
 }
 
 // Warning emits an WARNING level log
-func Warning(msg string, a ...any) {
+func Warning(msg string, a ...any) *Entry {
 	if currentLogLevel > WARNING {
-		return
+		return nil
 	}
-
-	log.Println(Entry{
+	entry := Entry{
 		Time:     time.Now().UTC().Format(time.RFC3339),
 		Severity: "WARNING",
 		Message:  fmt.Sprintf(msg, a...),
-	})
+	}
+	log.Println(entry)
+	return &entry
 }
 
 // Error emits an ERROR level log
-func Error(msg string, a ...any) {
+func Error(msg string, a ...any) *Entry {
 	if currentLogLevel > ERROR {
-		return
+		return nil
 	}
-
-	log.Println(Entry{
+	entry := Entry{
 		Time:     time.Now().UTC().Format(time.RFC3339),
 		Severity: "ERROR",
 		Message:  fmt.Errorf(msg, a...).Error(),
-	})
+	}
+	log.Println(entry)
+	return &entry
 }
 
 // Fatal emits an CRITICAL level log and stops the program

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -56,6 +56,10 @@ const (
 	ResourceCleanupError
 	// CommandError means there was an error with an external command
 	CommandError
+	// CloneDetail are log entries that are informational
+	CloneDetail
+	// ScanDetail are log entries that are informational
+	ScanDetail
 )
 
 var logCodeNames = [...]string{"NoCode", "CloneError", "ScanError", "ResourceCleanupError", "CommandError"}
@@ -216,6 +220,20 @@ func Error(msg string, a ...any) *Entry {
 	entry := Entry{
 		Time:     time.Now().UTC().Format(time.RFC3339),
 		Severity: "ERROR",
+		Message:  fmt.Errorf(msg, a...).Error(),
+	}
+	log.Println(entry)
+	return &entry
+}
+
+// Critical emits an CRITICAL level log
+func Critical(msg string, a ...any) *Entry {
+	if currentLogLevel > CRITICAL {
+		return nil
+	}
+	entry := Entry{
+		Time:     time.Now().UTC().Format(time.RFC3339),
+		Severity: "CRITICAL",
 		Message:  fmt.Errorf(msg, a...).Error(),
 	}
 	log.Println(entry)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -62,7 +62,7 @@ const (
 	ScanDetail
 )
 
-var logCodeNames = [...]string{"NoCode", "CloneError", "ScanError", "ResourceCleanupError", "CommandError"}
+var logCodeNames = [...]string{"NoCode", "CloneError", "ScanError", "ResourceCleanupError", "CommandError", "CloneDetail", "ScanDetail"}
 
 func (code LogCode) String() string {
 	return logCodeNames[code]

--- a/pkg/resource/container_image.go
+++ b/pkg/resource/container_image.go
@@ -173,7 +173,7 @@ func (r *ContainerImage) cloneRemoteResource(ctx context.Context, path string, r
 			for i, m := range indexManifest.Manifests {
 				if m.Platform.Architecture == r.options.Arch {
 					index = i
-					r.Info(logger.CloneError, "selected first %s container", r.options.Arch)
+					r.Info(logger.CloneDetail, "selected first %s container", r.options.Arch)
 					break
 				}
 			}

--- a/pkg/resource/container_image.go
+++ b/pkg/resource/container_image.go
@@ -178,7 +178,7 @@ func (r *ContainerImage) cloneRemoteResource(ctx context.Context, path string, r
 				}
 			}
 		} else {
-			r.Info(logger.CloneError, "manifest contains multiple options, defaulted to first (OS: %s, Arch: %s)",
+			r.Info(logger.CloneDetail, "manifest contains multiple options, defaulted to first (OS: %s, Arch: %s)",
 				indexManifest.Manifests[index].Platform.OS, indexManifest.Manifests[index].Platform.Architecture)
 		}
 		imgRefString := imageSource.Reference().DockerReference().Name() + "@" + indexManifest.Manifests[index].Digest.String()
@@ -226,14 +226,14 @@ func (r *ContainerImage) cloneRemoteResource(ctx context.Context, path string, r
 	for i, layer := range layers {
 		if since != nil && layerHistoryDates != nil {
 			if layerHistoryDates[i].Before(*since) {
-				r.Info(logger.CloneError, "layer older than provided date, skipping layer %s", layer.Digest.Hex())
+				r.Info(logger.CloneDetail, "layer older than provided date, skipping layer %s", layer.Digest.Hex())
 				continue
 			}
 		}
 		if r.skipLayer(layer.Digest.Hex()) {
 			continue
 		}
-		r.Debug(logger.CloneError, "downloading layer %s", layer.Digest.Hex())
+		r.Debug(logger.CloneDetail, "downloading layer %s", layer.Digest.Hex())
 
 		blobInfo := types.BlobInfo{
 			Digest: layer.Digest,
@@ -275,7 +275,7 @@ func (r *ContainerImage) copyN(dst string, src io.Reader, n int64) error {
 		return err
 	}
 	if written >= n {
-		r.Warning(logger.CloneError, "copying file %s did not finish due to max file size: %v", file.Name(), err)
+		r.Warning(logger.CloneDetail, "copying file %s did not finish due to max file size: %v", file.Name(), err)
 	}
 	return nil
 }
@@ -331,7 +331,7 @@ func (r *ContainerImage) extractLayer(t io.Reader, layer manifest.LayerInfo, pat
 			continue
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			r.Warning(logger.CloneError, "skipping file that is a symlink: %s", info.Name())
+			r.Warning(logger.CloneDetail, "skipping file that is a symlink: %s", info.Name())
 			continue
 		}
 
@@ -426,7 +426,7 @@ func (r *ContainerImage) sinceTime() *time.Time {
 func (r *ContainerImage) skipLayer(digest string) bool {
 	for _, exclude := range r.options.Exclusions {
 		if exclude == digest {
-			r.Info(logger.CloneError, "layer in exclusion list, skipping layer %s", digest)
+			r.Info(logger.CloneDetail, "layer in exclusion list, skipping layer %s", digest)
 			return true
 		}
 	}
@@ -463,7 +463,7 @@ func (r *ContainerImage) Walk(fn WalkFunc) error {
 		}
 
 		if info.Mode()&os.ModeSymlink != 0 {
-			r.Info(logger.ScanError, "skipping symlink: path=%q", relPath)
+			r.Info(logger.ScanDetail, "skipping symlink: path=%q", relPath)
 			return nil
 		}
 

--- a/pkg/resource/container_image.go
+++ b/pkg/resource/container_image.go
@@ -173,12 +173,12 @@ func (r *ContainerImage) cloneRemoteResource(ctx context.Context, path string, r
 			for i, m := range indexManifest.Manifests {
 				if m.Platform.Architecture == r.options.Arch {
 					index = i
-					logger.Info("selected first %s container", r.options.Arch)
+					r.Info(logger.CloneError, "selected first %s container", r.options.Arch)
 					break
 				}
 			}
 		} else {
-			logger.Info("manifest contains multiple options, defaulted to first (OS: %s, Arch: %s)",
+			r.Info(logger.CloneError, "manifest contains multiple options, defaulted to first (OS: %s, Arch: %s)",
 				indexManifest.Manifests[index].Platform.OS, indexManifest.Manifests[index].Platform.Architecture)
 		}
 		imgRefString := imageSource.Reference().DockerReference().Name() + "@" + indexManifest.Manifests[index].Digest.String()
@@ -226,14 +226,14 @@ func (r *ContainerImage) cloneRemoteResource(ctx context.Context, path string, r
 	for i, layer := range layers {
 		if since != nil && layerHistoryDates != nil {
 			if layerHistoryDates[i].Before(*since) {
-				logger.Info("layer older than provided date, skipping layer %s", layer.Digest.Hex())
+				r.Info(logger.CloneError, "layer older than provided date, skipping layer %s", layer.Digest.Hex())
 				continue
 			}
 		}
 		if r.skipLayer(layer.Digest.Hex()) {
 			continue
 		}
-		logger.Debug("downloading layer %s", layer.Digest.Hex())
+		r.Debug(logger.CloneError, "downloading layer %s", layer.Digest.Hex())
 
 		blobInfo := types.BlobInfo{
 			Digest: layer.Digest,
@@ -275,7 +275,7 @@ func (r *ContainerImage) copyN(dst string, src io.Reader, n int64) error {
 		return err
 	}
 	if written >= n {
-		logger.Warning("copying file %s did not finish due to max file size: %v", file.Name(), err)
+		r.Warning(logger.CloneError, "copying file %s did not finish due to max file size: %v", file.Name(), err)
 	}
 	return nil
 }
@@ -320,7 +320,7 @@ func (r *ContainerImage) extractLayer(t io.Reader, layer manifest.LayerInfo, pat
 		}
 		path, err := fs.CleanJoin(layerRootDir, header.Name)
 		if err != nil {
-			logger.Error("%v - skipped", err)
+			r.Error(logger.CloneError, "%v - skipped", err)
 			continue
 		}
 		info := header.FileInfo()
@@ -331,13 +331,13 @@ func (r *ContainerImage) extractLayer(t io.Reader, layer manifest.LayerInfo, pat
 			continue
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			logger.Warning("skipping file that is a symlink: %s", info.Name())
+			r.Warning(logger.CloneError, "skipping file that is a symlink: %s", info.Name())
 			continue
 		}
 
 		err = r.copyN(path, tarReader, size)
 		if err != nil {
-			logger.Error("could not create/write file: %v", err)
+			r.Error(logger.CloneError, "could not create/write file: %v", err)
 			// Try others, in case its unsupported file name for the filesystem etc.
 			continue
 		}
@@ -413,7 +413,7 @@ func (r *ContainerImage) sinceTime() *time.Time {
 	if len(r.options.Since) > 0 {
 		date, err := time.Parse("2006-01-02", r.options.Since)
 		if err != nil {
-			logger.Error("could not parse since time: %v", err)
+			r.Error(logger.CloneError, "could not parse since time: %v", err)
 			return nil
 		} else {
 			return &date
@@ -426,7 +426,7 @@ func (r *ContainerImage) sinceTime() *time.Time {
 func (r *ContainerImage) skipLayer(digest string) bool {
 	for _, exclude := range r.options.Exclusions {
 		if exclude == digest {
-			logger.Info("layer in exclusion list, skipping layer %s", digest)
+			r.Info(logger.CloneError, "layer in exclusion list, skipping layer %s", digest)
 			return true
 		}
 	}
@@ -443,13 +443,13 @@ func (r *ContainerImage) Walk(fn WalkFunc) error {
 	// TODO: consider calling JSONData and creating Files for these instead of walking this way
 	return filepath.WalkDir(r.ClonePath(), func(path string, d iofs.DirEntry, err error) error {
 		if err != nil {
-			logger.Error("could not walk path: path=%q error=%q", path, err)
+			r.Error(logger.ScanError, "could not walk path: path=%q error=%q", path, err)
 			return nil
 		}
 
 		relPath, err := filepath.Rel(r.ClonePath(), path)
 		if err != nil {
-			logger.Error("could generate relative path: path=%q error=%q", path, err)
+			r.Error(logger.ScanError, "could generate relative path: path=%q error=%q", path, err)
 			return nil
 		}
 
@@ -463,13 +463,13 @@ func (r *ContainerImage) Walk(fn WalkFunc) error {
 		}
 
 		if info.Mode()&os.ModeSymlink != 0 {
-			logger.Info("skipping symlink: path=%q", relPath)
+			r.Info(logger.ScanError, "skipping symlink: path=%q", relPath)
 			return nil
 		}
 
 		file, err := os.Open(filepath.Clean(path))
 		if err != nil {
-			logger.Error("could not open file: path=%q error=%q", relPath, err)
+			r.Error(logger.ScanError, "could not open file: path=%q error=%q", relPath, err)
 			return nil
 		}
 		defer file.Close()

--- a/pkg/resource/files.go
+++ b/pkg/resource/files.go
@@ -103,13 +103,13 @@ func (r *Files) Walk(fn WalkFunc) error {
 
 	return filepath.WalkDir(r.path, func(path string, d iofs.DirEntry, err error) error {
 		if err != nil {
-			logger.Error("could not walk path: path=%q error=%q", path, err)
+			r.Error(logger.ScanError, "could not walk path: path=%q error=%q", path, err)
 			return nil
 		}
 
 		relPath, err := filepath.Rel(r.path, path)
 		if err != nil {
-			logger.Error("could generate relative path: path=%q error=%q", path, err)
+			r.Error(logger.ScanError, "could generate relative path: path=%q error=%q", path, err)
 			return nil
 		}
 
@@ -123,13 +123,13 @@ func (r *Files) Walk(fn WalkFunc) error {
 		}
 
 		if info.Mode()&os.ModeSymlink != 0 {
-			logger.Info("skipping symlink: path=%q", relPath)
+			r.Info(logger.ScanError, "skipping symlink: path=%q", relPath)
 			return nil
 		}
 
 		file, err := os.Open(filepath.Clean(path))
 		if err != nil {
-			logger.Error("could not open file: path=%q error=%q", relPath, err)
+			r.Error(logger.ScanError, "could not open file: path=%q error=%q", relPath, err)
 			return nil
 		}
 		defer file.Close()

--- a/pkg/resource/files.go
+++ b/pkg/resource/files.go
@@ -123,7 +123,7 @@ func (r *Files) Walk(fn WalkFunc) error {
 		}
 
 		if info.Mode()&os.ModeSymlink != 0 {
-			r.Info(logger.ScanError, "skipping symlink: path=%q", relPath)
+			r.Info(logger.ScanDetail, "skipping symlink: path=%q", relPath)
 			return nil
 		}
 

--- a/pkg/resource/git.go
+++ b/pkg/resource/git.go
@@ -91,7 +91,7 @@ func (r *GitRepo) Clone(path string) error {
 			cloneArgs = append(cloneArgs, "--branch")
 			cloneArgs = append(cloneArgs, r.options.Branch)
 		} else {
-			r.Warning(logger.CloneError, "ignoring invalid branch: branch=%q", r.options.Branch)
+			r.Warning(logger.CloneDetail, "ignoring invalid branch: branch=%q", r.options.Branch)
 			cloneArgs = append(cloneArgs, "--no-single-branch")
 		}
 	} else {
@@ -128,7 +128,7 @@ func (r *GitRepo) Clone(path string) error {
 		return fmt.Errorf("git clone: resource_id=%q command=%q error=%q output=%q", r.ID(), gitClone.String(), err.Error(), output)
 	}
 
-	r.Debug(logger.CloneError, "git clone: resource_id=%q command=%q output=%q", r.ID(), gitClone.String(), output)
+	r.Debug(logger.CloneDetail, "git clone: resource_id=%q command=%q output=%q", r.ID(), gitClone.String(), output)
 
 	if ctx != nil && ctx.Err() == context.DeadlineExceeded {
 		return fmt.Errorf("clone timeout exceeded resource_id=%q error=%q", r.ID(), ctx.Err().Error())

--- a/pkg/resource/git.go
+++ b/pkg/resource/git.go
@@ -91,7 +91,7 @@ func (r *GitRepo) Clone(path string) error {
 			cloneArgs = append(cloneArgs, "--branch")
 			cloneArgs = append(cloneArgs, r.options.Branch)
 		} else {
-			logger.Warning("ignoring invalid branch: branch=%q", r.options.Branch)
+			r.Warning(logger.CloneError, "ignoring invalid branch: branch=%q", r.options.Branch)
 			cloneArgs = append(cloneArgs, "--no-single-branch")
 		}
 	} else {
@@ -128,7 +128,7 @@ func (r *GitRepo) Clone(path string) error {
 		return fmt.Errorf("git clone: resource_id=%q command=%q error=%q output=%q", r.ID(), gitClone.String(), err.Error(), output)
 	}
 
-	logger.Debug("git clone: resource_id=%q command=%q output=%q", r.ID(), gitClone.String(), output)
+	r.Debug(logger.CloneError, "git clone: resource_id=%q command=%q output=%q", r.ID(), gitClone.String(), output)
 
 	if ctx != nil && ctx.Err() == context.DeadlineExceeded {
 		return fmt.Errorf("clone timeout exceeded resource_id=%q error=%q", r.ID(), ctx.Err().Error())
@@ -247,7 +247,7 @@ func (r *GitRepo) Refs() []string {
 	refs := []string{}
 
 	if err != nil {
-		logger.Error("could not list refs: error=%q", err)
+		r.Error(logger.CommandError, "could not list refs: error=%q", err)
 		return refs
 	}
 

--- a/pkg/resource/json_data.go
+++ b/pkg/resource/json_data.go
@@ -74,7 +74,7 @@ func (r *JSONData) Clone(path string) error {
 
 	// Load the raw json into the data variable
 	if err = json.Unmarshal([]byte(r.raw), &r.data); err != nil {
-		logger.Debug("JSONData:\n%v", r.raw)
+		r.Debug(logger.ScanError, "JSONData:\n%v", r.raw)
 		return fmt.Errorf("could not unmarshal JSONData: error=%q", err)
 	}
 
@@ -117,7 +117,7 @@ func (r *JSONData) fetchURLs(rootNode jsonNode, clonePath string) error {
 		if err != nil {
 			// Not being able to retrieve a URL found inside JSONData is not a fatal error. Logging until update how
 			// we manage fatal/nonfatal errors flowing through the application.
-			logger.Info("%v", fmt.Errorf("could not fetch url: path=%q url=%q error=%q", leafNode.path, obj, err))
+			r.Warning(logger.CloneError, "%v", fmt.Errorf("could not fetch url: path=%q url=%q error=%q", leafNode.path, obj, err))
 			return nil
 		}
 

--- a/pkg/resource/json_data.go
+++ b/pkg/resource/json_data.go
@@ -74,7 +74,7 @@ func (r *JSONData) Clone(path string) error {
 
 	// Load the raw json into the data variable
 	if err = json.Unmarshal([]byte(r.raw), &r.data); err != nil {
-		r.Debug(logger.ScanError, "JSONData:\n%v", r.raw)
+		r.Debug(logger.ScanDetail, "JSONData:\n%v", r.raw)
 		return fmt.Errorf("could not unmarshal JSONData: error=%q", err)
 	}
 
@@ -117,7 +117,7 @@ func (r *JSONData) fetchURLs(rootNode jsonNode, clonePath string) error {
 		if err != nil {
 			// Not being able to retrieve a URL found inside JSONData is not a fatal error. Logging until update how
 			// we manage fatal/nonfatal errors flowing through the application.
-			r.Warning(logger.CloneError, "%v", fmt.Errorf("could not fetch url: path=%q url=%q error=%q", leafNode.path, obj, err))
+			r.Error(logger.CloneError, "%v", fmt.Errorf("could not fetch url: path=%q url=%q error=%q", leafNode.path, obj, err))
 			return nil
 		}
 

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -133,7 +133,9 @@ func (r *BaseResource) Logs() []logger.Entry {
 // Critical forwards to the logger and adds to the resource logs used for critical errors that interupt
 // the scanner flow.
 func (r *BaseResource) Critical(code logger.ErrorCode, msg string, args ...any) {
-	if entry := logger.Error(msg, args...); entry != nil {
+	resourceMsg := fmt.Sprintf("resource_id=%s ", r.id)
+	if entry := logger.Error(resourceMsg+msg, args...); entry != nil {
+		entry.Message = fmt.Errorf(msg, args...).Error()
 		entry.Code = code.String()
 		entry.Severity = "CRITICAL"
 		r.logs = append(r.logs, *entry)
@@ -142,7 +144,9 @@ func (r *BaseResource) Critical(code logger.ErrorCode, msg string, args ...any) 
 
 // Debug forwards to the logger and adds to the resource logs based on log level
 func (r *BaseResource) Debug(code logger.ErrorCode, msg string, args ...any) {
-	if entry := logger.Debug(msg, args...); entry != nil {
+	resourceMsg := fmt.Sprintf("resource_id=%s ", r.id)
+	if entry := logger.Debug(resourceMsg+msg, args...); entry != nil {
+		entry.Message = fmt.Errorf(msg, args...).Error()
 		entry.Code = code.String()
 		if r.LogsInResponse {
 			r.logs = append(r.logs, *entry)
@@ -152,7 +156,9 @@ func (r *BaseResource) Debug(code logger.ErrorCode, msg string, args ...any) {
 
 // Error forwards to the logger and adds to the resource logs based on log level
 func (r *BaseResource) Error(code logger.ErrorCode, msg string, args ...any) {
-	if entry := logger.Error(msg, args...); entry != nil {
+	resourceMsg := fmt.Sprintf("resource_id=%s ", r.id)
+	if entry := logger.Error(resourceMsg+msg, args...); entry != nil {
+		entry.Message = fmt.Errorf(msg, args...).Error()
 		entry.Code = code.String()
 		if r.LogsInResponse {
 			r.logs = append(r.logs, *entry)
@@ -162,7 +168,9 @@ func (r *BaseResource) Error(code logger.ErrorCode, msg string, args ...any) {
 
 // Warning forwards to the logger and adds to the resource logs based on log level
 func (r *BaseResource) Warning(code logger.ErrorCode, msg string, args ...any) {
-	if entry := logger.Warning(msg, args...); entry != nil {
+	resourceMsg := fmt.Sprintf("resource_id=%s ", r.id)
+	if entry := logger.Warning(resourceMsg+msg, args...); entry != nil {
+		entry.Message = fmt.Errorf(msg, args...).Error()
 		entry.Code = code.String()
 		if r.LogsInResponse {
 			r.logs = append(r.logs, *entry)
@@ -172,7 +180,9 @@ func (r *BaseResource) Warning(code logger.ErrorCode, msg string, args ...any) {
 
 // Info forwards to the logger and adds to the resource logs based on log level
 func (r *BaseResource) Info(code logger.ErrorCode, msg string, args ...any) {
-	if entry := logger.Info(msg, args...); entry != nil {
+	resourceMsg := fmt.Sprintf("resource_id=%s ", r.id)
+	if entry := logger.Info(resourceMsg+msg, args...); entry != nil {
+		entry.Message = fmt.Errorf(msg, args...).Error()
 		entry.Code = code.String()
 		if r.LogsInResponse {
 			r.logs = append(r.logs, *entry)

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -34,7 +34,7 @@ type Resource interface {
 	ReadFile(path string) ([]byte, error)
 	SetCloneTimeout(timeout time.Duration)
 	SetDepth(depth uint16)
-	SetResourceLogs(enabled bool)
+	IncludeLogs(enabled bool)
 	Since() string
 	String() string
 	// Walk is the main way to pick through resource data (except for GitRepo)
@@ -114,7 +114,7 @@ func NewResource(kind, resource string, options json.RawMessage) (Resource, erro
 type BaseResource struct {
 	id             string
 	logs           []logger.Entry
-	LogsInResponse bool
+	includeLogs bool
 }
 
 // ID returns a path-safe, unique id for this resource
@@ -133,8 +133,8 @@ func (r *BaseResource) Logs() []logger.Entry {
 // Critical forwards to the logger and adds to the resource logs used for critical errors that interupt
 // the scanner flow.
 func (r *BaseResource) Critical(code logger.ErrorCode, msg string, args ...any) {
-	resourceMsg := fmt.Sprintf("resource_id=%s ", r.id)
-	if entry := logger.Error(resourceMsg+msg, args...); entry != nil {
+	resourceMsg := fmt.Sprintf("resource_id=%s %s", r.id, msg)
+	if entry := logger.Critical(resourceMsg, args...); entry != nil {
 		entry.Message = fmt.Errorf(msg, args...).Error()
 		entry.Code = code.String()
 		entry.Severity = "CRITICAL"

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -137,7 +137,6 @@ func (r *BaseResource) Critical(code logger.LogCode, msg string, args ...any) {
 	if entry := logger.Critical(resourceMsg, args...); entry != nil {
 		entry.Message = fmt.Errorf(msg, args...).Error()
 		entry.Code = code.String()
-		entry.Severity = "CRITICAL"
 		r.logs = append(r.logs, *entry)
 	}
 }

--- a/pkg/response/error.go
+++ b/pkg/response/error.go
@@ -2,7 +2,7 @@ package response
 
 import "fmt"
 
-// LeakTKError expans a normal error to provide additional meta data
+// LeakTKError expands a normal error to provide additional meta data
 type LeakTKError struct {
 	Fatal   bool      `json:"fatal"`
 	Code    ErrorCode `json:"code"`

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -19,10 +19,10 @@ const (
 type (
 	// Response from the scanner with the scan results
 	Response struct {
-		ID        string        `json:"id"`
-		Errors    []LeakTKError `json:"errors"`
-		RequestID string        `json:"request_id"`
-		Results   []*Result     `json:"results"`
+		ID        string         `json:"id"`
+		Logs      []logger.Entry `json:"logs"`
+		RequestID string         `json:"request_id"`
+		Results   []*Result      `json:"results"`
 	}
 
 	// Result of a scan

--- a/pkg/scanner/request.go
+++ b/pkg/scanner/request.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/leaktk/scanner/pkg/logger"
 	"github.com/leaktk/scanner/pkg/resource"
-	"github.com/leaktk/scanner/pkg/response"
 )
 
 // Request to the scanner to scan some resource
@@ -15,7 +14,6 @@ type Request struct {
 	ID string
 	// Thing to scan (e.g. URL, snippet of text, etc)
 	Resource resource.Resource
-	Errors   []response.LeakTKError
 }
 
 // Return the Priority of this request

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -89,7 +89,7 @@ func (s *Scanner) listenForCloneRequests() {
 	s.cloneQueue.Recv(func(msg *queue.Message[*Request]) {
 		request := msg.Value
 		reqResource := request.Resource
-		reqResource.SetResourceLogs(s.includeResponseLogs)
+		reqResource.IncludeLogs(s.includeResponseLogs)
 
 		if s.cloneTimeout > 0 {
 			logger.Debug("setting clone timeout: request_id=%q timeout=%v", request.ID, s.cloneTimeout.Seconds())

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -148,10 +148,10 @@ func (s *Scanner) listenForScanRequests() {
 				}
 			}
 			if err := s.removeResourceFiles(reqResource); err != nil {
-				reqResource.Critical(logger.ResourceCleanupError, "resource file cleanup error: request_id=%q error=%q", request.ID, err.Error())
+				reqResource.Error(logger.ResourceCleanupError, "resource file cleanup error: request_id=%q error=%q", request.ID, err.Error())
 			}
 		} else {
-			reqResource.Critical(logger.CloneError, "skipping scan due to missing clone path: request_id=%q", request.ID)
+			reqResource.Critical(logger.ScanError, "skipping scan due to missing clone path: request_id=%q", request.ID)
 
 		}
 


### PR DESCRIPTION
Braxton and I discussed how to best provide logs to users of the service.

This is was the approach that was decided. Collect the logs, at the same level the service does(LEAKTK_LOGGER_LEVEL), and return them to the user. 
Whether all logs are returned or only those that are CRITICAL (fatal - mean the scan did not occur) is configurable and off by default.