### PR TITLE
Give group same file permissions as owner

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,7 +100,7 @@ func setMissingValues(cfg *Config) *Config {
 func leaktkConfigDir() string {
 	path := filepath.Join(xdg.ConfigHome, "leaktk")
 
-	if err := os.MkdirAll(path, 0700); err != nil {
+	if err := os.MkdirAll(path, 0770); err != nil {
 		logger.Error("could not create dir: path=%q", path)
 	}
 
@@ -110,7 +110,7 @@ func leaktkConfigDir() string {
 func leaktkCacheDir() string {
 	path := filepath.Join(xdg.CacheHome, "leaktk")
 
-	if err := os.MkdirAll(path, 0700); err != nil {
+	if err := os.MkdirAll(path, 0770); err != nil {
 		logger.Error("could not create dir: path=%q", path)
 	}
 
@@ -245,7 +245,7 @@ func LocateAndLoadConfig(path string) (*Config, error) {
 func SavePatternServerAuthToken(authToken string) error {
 	path := localPatternServerAuthTokenPath()
 
-	if err := os.WriteFile(path, []byte(strings.TrimSpace(authToken)), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(authToken)), 0660); err != nil {
 		return err
 	}
 

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -17,7 +17,7 @@ func TestFileExists(t *testing.T) {
 	})
 
 	t.Run("FileExists", func(t *testing.T) {
-		err := os.WriteFile(tmpFile, []byte{}, 0600)
+		err := os.WriteFile(tmpFile, []byte{}, 0660)
 		assert.NoError(t, err)
 		assert.True(t, FileExists(tmpFile))
 	})
@@ -37,7 +37,7 @@ func TestPathExists(t *testing.T) {
 	})
 
 	t.Run("FileExists", func(t *testing.T) {
-		err := os.WriteFile(tmpFile, []byte{}, 0600)
+		err := os.WriteFile(tmpFile, []byte{}, 0660)
 		assert.NoError(t, err)
 		assert.True(t, PathExists(tmpFile))
 	})
@@ -56,7 +56,7 @@ func TestPathExists(t *testing.T) {
 func TestCleanJoin(t *testing.T) {
 	t.Run("CleanJoin", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		err := os.MkdirAll(filepath.Join(tmpDir, "foo"), 0700)
+		err := os.MkdirAll(filepath.Join(tmpDir, "foo"), 0770)
 		assert.NoError(t, err)
 
 		testPathFail := "../../hello/world"

--- a/pkg/resource/container_image.go
+++ b/pkg/resource/container_image.go
@@ -118,7 +118,7 @@ func (r *ContainerImage) String() string {
 
 // Clone the resource to the desired clonePath location
 func (r *ContainerImage) Clone(path string) error {
-	err := os.MkdirAll(path, 0700)
+	err := os.MkdirAll(path, 0770)
 	if err != nil {
 		return fmt.Errorf("could not create clone directory: %v", err)
 	}
@@ -258,11 +258,11 @@ func (r *ContainerImage) cloneRemoteResource(ctx context.Context, path string, r
 }
 
 func (r *ContainerImage) writeFile(filename string, content []byte) error {
-	return os.WriteFile(filepath.Join(r.clonePath, filename), content, 0600)
+	return os.WriteFile(filepath.Join(r.clonePath, filename), content, 0660)
 }
 
 func (r *ContainerImage) copyN(dst string, src io.Reader, n int64) error {
-	file, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600) // #nosec G304
+	file, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0660) // #nosec G304
 	if err != nil {
 		return err
 	}
@@ -286,7 +286,7 @@ func (r *ContainerImage) extractLayer(t io.Reader, layer manifest.LayerInfo, pat
 	size := layer.Size * 10
 	layerRootDir := filepath.Join(r.ClonePath(), layer.Digest.Hex())
 	layerDir := filepath.Join(path, layer.Digest.Hex())
-	err := os.MkdirAll(layerDir, 0700)
+	err := os.MkdirAll(layerDir, 0770)
 	if err != nil {
 		return fmt.Errorf("could not create layer directory: %v", err)
 	}
@@ -325,7 +325,7 @@ func (r *ContainerImage) extractLayer(t io.Reader, layer manifest.LayerInfo, pat
 		}
 		info := header.FileInfo()
 		if info.IsDir() {
-			if err = os.MkdirAll(path, 0700); err != nil {
+			if err = os.MkdirAll(path, 0770); err != nil {
 				return fmt.Errorf("could not create directory: %v", err)
 			}
 			continue

--- a/pkg/resource/files_test.go
+++ b/pkg/resource/files_test.go
@@ -12,13 +12,13 @@ import (
 func TestFiles(t *testing.T) {
 	// Set up dir structure
 	tmpDir := t.TempDir()
-	err := os.MkdirAll(filepath.Join(tmpDir, "foo"), 0700)
+	err := os.MkdirAll(filepath.Join(tmpDir, "foo"), 0770)
 	assert.NoError(t, err)
 
 	// Write test file
 	testFileData := []byte("Hello, world!\n")
 	testFilePath := filepath.Join(tmpDir, "foo", "test-file")
-	err = os.WriteFile(testFilePath, testFileData, 0600)
+	err = os.WriteFile(testFilePath, testFileData, 0660)
 	assert.NoError(t, err)
 
 	// Create testing object

--- a/pkg/resource/json_data.go
+++ b/pkg/resource/json_data.go
@@ -70,7 +70,7 @@ func (r *JSONData) Clone(path string) error {
 
 	r.clonePath = path
 
-	if err = os.MkdirAll(r.clonePath, 0700); err != nil {
+	if err = os.MkdirAll(r.clonePath, 0770); err != nil {
 		return err
 	}
 
@@ -87,7 +87,7 @@ func (r *JSONData) Clone(path string) error {
 		".gitleaksbaseline",
 	} {
 		if data, err := r.ReadFile(file); err == nil {
-			if err = os.WriteFile(filepath.Join(r.clonePath, file), data, 0600); err != nil {
+			if err = os.WriteFile(filepath.Join(r.clonePath, file), data, 0660); err != nil {
 				return err
 			}
 		}

--- a/pkg/resource/url.go
+++ b/pkg/resource/url.go
@@ -70,14 +70,14 @@ func (r *URL) Clone(path string) error {
 		// Scan as a JSONData resource
 		r.resource = NewJSONData(string(data), &JSONDataOptions{})
 	} else {
-		if err := os.MkdirAll(r.clonePath, 0700); err != nil {
+		if err := os.MkdirAll(r.clonePath, 0770); err != nil {
 			return fmt.Errorf("could not create clone path: path=%q error=%q", r.clonePath, err)
 		}
 
 		// Use ID(r.url) to create the dataPath so that we don't have collisions
 		// for if we follow URLs in the returned content
 		dataPath := filepath.Clean(filepath.Join(r.clonePath, id.ID(r.url)))
-		dataFile, err := os.OpenFile(dataPath, os.O_WRONLY|os.O_CREATE, 0600)
+		dataFile, err := os.OpenFile(dataPath, os.O_WRONLY|os.O_CREATE, 0660)
 		if err != nil {
 			return fmt.Errorf("could not open data file: error=%q", err)
 		}

--- a/pkg/scanner/gitleaks_test.go
+++ b/pkg/scanner/gitleaks_test.go
@@ -27,7 +27,7 @@ func TestGitleaksScan(t *testing.T) {
 
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "gitleaks.toml")
-	err = os.WriteFile(configPath, []byte(mockGitleaksTestConfig), 0600)
+	err = os.WriteFile(configPath, []byte(mockGitleaksTestConfig), 0660)
 	assert.NoError(t, err)
 	cfg := config.DefaultConfig()
 	cfg.Scanner.Patterns.Gitleaks.ConfigPath = configPath

--- a/pkg/scanner/patterns.go
+++ b/pkg/scanner/patterns.go
@@ -107,13 +107,13 @@ func (p *Patterns) Gitleaks() (*gitleaksconfig.Config, error) {
 			return p.gitleaksConfig, fmt.Errorf("could not parse config: error=%q", err)
 		}
 
-		if err := os.MkdirAll(filepath.Dir(p.config.Gitleaks.ConfigPath), 0700); err != nil {
+		if err := os.MkdirAll(filepath.Dir(p.config.Gitleaks.ConfigPath), 0770); err != nil {
 			return p.gitleaksConfig, fmt.Errorf("could not create config dir: error=%q", err)
 		}
 
 		// only write the config after parsing it, that way we don't break a good
 		// existing config if the server returns an invalid response
-		if err := os.WriteFile(p.config.Gitleaks.ConfigPath, []byte(rawConfig), 0600); err != nil {
+		if err := os.WriteFile(p.config.Gitleaks.ConfigPath, []byte(rawConfig), 0660); err != nil {
 			return p.gitleaksConfig, fmt.Errorf("could not write config: path=%q error=%q", p.config.Gitleaks.ConfigPath, err)
 		}
 		p.updateGitleaksConfigHash(sha256.Sum256([]byte(rawConfig)))

--- a/pkg/scanner/patterns_test.go
+++ b/pkg/scanner/patterns_test.go
@@ -113,7 +113,7 @@ func TestGitleaksConfigModTimeExceeds(t *testing.T) {
 		tempDir := t.TempDir()
 
 		tempFilePath := filepath.Join(tempDir, "gitleaks.toml")
-		err := os.WriteFile(tempFilePath, []byte{}, 0600)
+		err := os.WriteFile(tempFilePath, []byte{}, 0660)
 		assert.NoError(t, err)
 
 		// Set the file's modification time to 10 seconds ago
@@ -208,7 +208,7 @@ func TestPatternsGitleaks(t *testing.T) {
 	configFilePath := filepath.Join(tempDir, "gitleaks.toml")
 
 	getPatterns := func(autofetch bool, refreshAfter, expiredAfter, modTime uint32) *Patterns {
-		err := os.WriteFile(configFilePath, []byte(mockConfig), 0600)
+		err := os.WriteFile(configFilePath, []byte(mockConfig), 0660)
 		assert.NoError(t, err)
 
 		// Set the file's modification time to 15 seconds ago

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -38,7 +38,7 @@ func (m *mockResource) ReadFile(path string) ([]byte, error) {
 
 func (m *mockResource) Clone(path string) error {
 	m.clonePath = path
-	_ = os.MkdirAll(m.clonePath, 0700)
+	_ = os.MkdirAll(m.clonePath, 0770)
 	return m.cloneErr
 }
 


### PR DESCRIPTION
This should help in containerized contexts where uid might not be consistent.

