### PR TITLE
Logging changes

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestPartialLoadConfigFromFile(t *testing.T) {
 	os.Setenv("LEAKTK_PATTERN_SERVER_AUTH_TOKEN", "x")
+	os.Unsetenv("LEAKTK_PATTERN_SERVER_URL")
 	cfg, err := LoadConfigFromFile("../../testdata/partial-config.toml")
 
 	if err != nil {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -66,7 +66,7 @@ func (s *Scanner) Recv(fn func(*response.Response)) {
 
 // Send accepts a request for scanning and puts it in the queues
 func (s *Scanner) Send(request *Request) {
-	logger.Debug("queueing clone: request_id=%q", request.ID)
+	logger.Info("queueing clone: request_id=%q resource_id=%q", request.ID, request.Resource.ID())
 	s.cloneQueue.Send(&queue.Message[*Request]{
 		Priority: request.Priority(),
 		Value:    request,
@@ -112,7 +112,7 @@ func (s *Scanner) listenForCloneRequests() {
 		}
 
 		// Now that it's cloned send it on to the scan queue
-		logger.Debug("queueing scan: request_id=%q", request.ID)
+		logger.Info("queueing scan: request_id=%q resource_id=%q", request.ID, reqResource.ID())
 		s.scanQueue.Send(msg)
 	})
 }
@@ -158,6 +158,7 @@ func (s *Scanner) listenForScanRequests() {
 
 		}
 
+		logger.Info("queueing response: request_id=%q resource_id=%q", request.ID, reqResource.ID())
 		s.responseQueue.Send(&queue.Message[*response.Response]{
 			Priority: msg.Priority,
 			Value: &response.Response{

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -95,17 +95,17 @@ func (s *Scanner) listenForCloneRequests() {
 		reqResource.IncludeLogs(s.includeResponseLogs)
 
 		if s.cloneTimeout > 0 {
-			logger.Debug("setting clone timeout: request_id=%q timeout=%v", request.ID, s.cloneTimeout.Seconds())
+			logger.Debug("setting clone timeout: request_id=%q resource_id=%q timeout=%v", request.ID, reqResource.ID(), s.cloneTimeout.Seconds())
 			reqResource.SetCloneTimeout(s.cloneTimeout)
 		}
 
 		if s.maxScanDepth > 0 && reqResource.Depth() > s.maxScanDepth {
-			logger.Warning("reducing scan depth: request_id=%q old_depth=%v new_depth=%v", request.ID, reqResource.Depth(), s.maxScanDepth)
+			logger.Warning("reducing scan depth: request_id=%q resource_id=%q old_depth=%v new_depth=%v", request.ID, reqResource.ID(), reqResource.Depth(), s.maxScanDepth)
 			reqResource.SetDepth(s.maxScanDepth)
 		}
 
 		if reqResource.ClonePath() == "" {
-			logger.Info("starting clone: request_id=%q", request.ID)
+			logger.Info("starting clone: request_id=%q resource_id=%q", request.ID, reqResource.ID())
 			if err := reqResource.Clone(s.resourceClonePath(reqResource)); err != nil {
 				reqResource.Critical(logger.CloneError, "clone error: request_id=%q error=%q", request.ID, err.Error())
 			}
@@ -140,7 +140,7 @@ func (s *Scanner) listenForScanRequests() {
 
 		if fs.PathExists(reqResource.ClonePath()) {
 			for _, backend := range s.backends {
-				logger.Info("starting scan: request_id=%q scanner_backend=%q", request.ID, backend.Name())
+				logger.Info("starting scan: request_id=%q resource_id=%q scanner_backend=%q", request.ID, reqResource.ID(), backend.Name())
 
 				backendResults, err := backend.Scan(reqResource)
 				if err != nil {


### PR DESCRIPTION
Goal: Help associate requests and other deeper logs that only have the resource_id and the three different logs help for keeping counts of how big the queues are getting.

Example logs:

```
[INFO] queueing clone: request_id="f2ac097b1ae62c651b8d81fbd246761b68091854724f09fd8fa2bc5e0d02ef3f" resource_id="a04e9e330d2f6d385670e12054d7fa6366dde11512bd5ddad31e472d82596138"
[INFO] starting clone: request_id="f2ac097b1ae62c651b8d81fbd246761b68091854724f09fd8fa2bc5e0d02ef3f" resource_id="a04e9e330d2f6d385670e12054d7fa6366dde11512bd5ddad31e472d82596138"
[INFO] queueing scan: request_id="f2ac097b1ae62c651b8d81fbd246761b68091854724f09fd8fa2bc5e0d02ef3f" resource_id="a04e9e330d2f6d385670e12054d7fa6366dde11512bd5ddad31e472d82596138"
[INFO] starting scan: request_id="f2ac097b1ae62c651b8d81fbd246761b68091854724f09fd8fa2bc5e0d02ef3f" resource_id="a04e9e330d2f6d385670e12054d7fa6366dde11512bd5ddad31e472d82596138" scanner_backend="Gitleaks"
[INFO] updated gitleaks patterns: hash=3797a90bac509533ff2abee131751649b38d8f7ce7c0d86622389ed9bf44f3e7
[INFO] gitleaks: 339 commits scanned.
[INFO] queueing response: request_id="f2ac097b1ae62c651b8d81fbd246761b68091854724f09fd8fa2bc5e0d02ef3f" resource_id="a04e9e330d2f6d385670e12054d7fa6366dde11512bd5ddad31e472d82596138"
```