### PR TITLE
Shorten IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Notes about the formats below:
 
 ```json
 {
-  "id": "db0c21127a6a849fdf8eeae65d753275f3a26a33649171fa34af458030744999",
+  "id": "85V5qL7x_bY",
   "kind": "GitRepo",
   "resource": "https://github.com/leaktk/fake-leaks.git",
   "options": {
@@ -136,23 +136,23 @@ Sets the request priority. Higher priority items will be scanned first.
 
 ```json
 {
-  "id": "8343516f29a9c80cc7862e01799f446d5fb93088d1681f8c5181b211488a94db",
+  "id": "rMr0GAfwYwd",
   "request": {
-    "id": "db0c21127a6a849fdf8eeae65d753275f3a26a33649171fa34af458030744999",
+    "id": "85V5qL7x_bY",
     "kind": "GitRepo",
     "resource": "http://github.com/leaktk/fake-leaks.git"
   },
   "logs": [],
   "results": [
     {
-      "id": "c80efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7",
+      "id": "IDsQnA1t6Em",
       "kind": "GitCommit",
       "secret": "-----BEGIN EC PRIVATE KEY-----\n...snip...\n-----END EC PRIVATE KEY-----",
       "match": "-----BEGIN EC PRIVATE KEY-----\n...snip...\n-----END EC PRIVATE KEY-----",
       "entropy": 5.763853,
       "date": "2023-08-04T12:21:12Z",
       "rule": {
-        "id": "private-key",
+        "id": "3fk1rL-aRiw",
         "description": "Private Key",
         "tags": [
           "group:leaktk-testing",
@@ -192,7 +192,7 @@ This allows you to scan various JSON structures for secrets.
 
 ```json
 {
-  "id": "580efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7",
+  "id": "OBZMFe4gBnt",
   "kind": "JSONData",
   "resource": "{\"some\": {\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}"
 }
@@ -245,23 +245,23 @@ Sets the request priority. Higher priority items will be scanned first.
 
 ```json
 {
-  "id": "c88057777737115851ad94b91461d09b2ce704484813557895ba0d6d827d4ed8",
+  "id": "tMd_Av-ZTFP",
   "request": {
-    "id": "580efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7",
+    "id": "Dg9hdRRdd2M",
     "kind": "JSONData",
     "resource": "{\"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}"
   },
   "logs": [],
   "results": [
     {
-      "id": "66456b43e1efac03f9448ece59a65b0e2bf304b55506507a8aa07727e3900522",
+      "id": "ZwaaqRjgNgk",
       "kind": "JSONData",
       "secret": "-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----",
       "match": "-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----",
       "entropy": 4.490795,
       "date": "",
       "rule": {
-        "id": "private-key",
+        "id": "3fk1rL-aRiw",
         "description": "Private Key",
         "tags": [
           "group:leaktk-testing",
@@ -302,7 +302,7 @@ This allows you to scan files and directories.
 
 ```json
 {
-  "id": "1c7387179582ae1e9bc114bfa10bddc6317fe6a5362efd2ae4019e34cccd8420",
+  "id": "04mTfB9Lxd1",
   "kind": "Files",
   "resource": "/path/to/fake-leaks/keys/tls"
 }
@@ -323,23 +323,23 @@ Sets the request priority. Higher priority items will be scanned first.
 
 ```json
 {
-  "id": "bde3a15ca81cf6503b9c9e1a450a3bbdfa09567e77f787a6cf4a56ed3b115f87",
+  "id": "cAdqKrap5Hu",
   "request": {
-    "id": "1c7387179582ae1e9bc114bfa10bddc6317fe6a5362efd2ae4019e34cccd8420",
+    "id": "A18dGVI86dm",
     "kind": "Files",
     "resource": "/path/to/fake-leaks/keys/tls"
   },
   "logs": [],
   "results": [
     {
-      "id": "9376e604a7e8c4f5259ceb47f8a29c57e77c07668e317fa8c177de5e56fbe029",
+      "id": "oOp7aV7LASW",
       "kind": "General",
       "secret": "-----BEGIN EC PRIVATE KEY-----\n...snip...\n-----END EC PRIVATE KEY-----",
       "match": "-----BEGIN EC PRIVATE KEY-----\n...snip...\n-----END EC PRIVATE KEY-----",
       "entropy": 5.763853,
       "date": "",
       "rule": {
-        "id": "private-key",
+        "id": "3fk1rL-aRiw",
         "description": "Private Key",
         "tags": [
           "group:leaktk-testing",
@@ -383,7 +383,7 @@ be parsed as a `Files` request.
 
 ```json
 {
-  "id": "1c7387179582ae1e9bc114bfa10bddc6317fe6a5362efd2ae4019e34cccd8420",
+  "id": "r-3Y5aAIckV",
   "kind": "URL",
   "resource": "https://raw.githubusercontent.com/leaktk/fake-leaks/main/keys/tls/server.key"
 }
@@ -402,23 +402,23 @@ Sets the request priority. Higher priority items will be scanned first.
 
 ```json
 {
-  "id": "a1ef32d00c609b370d2181ea46babbbdd19deeeea68918cc676a8f12d1fc7e3b",
+  "id": "r-3Y5aAIckV",
   "request": {
-    "id": "1c7387179582ae1e9bc114bfa10bddc6317fe6a5362efd2ae4019e34cccd8420",
+    "id": "DrlFMAs-m-D",
     "kind": "URL",
     "resource": "https://raw.githubusercontent.com/leaktk/fake-leaks/main/keys/tls/server.key"
   },
   "logs": [],
   "results": [
     {
-      "id": "6c14f496a2111dfeecbfff4a61587b0b1866788a6112b420f80071f8cded0153",
+      "id": "Czoctar4oKt",
       "kind": "General",
       "secret": "-----BEGIN PRIVATE KEY-----\n...snip...\n-----END PRIVATE KEY-----",
       "match": "-----BEGIN PRIVATE KEY-----\n...snip...\n-----END PRIVATE KEY-----",
       "entropy": 6.0285063,
       "date": "",
       "rule": {
-        "id": "private-key",
+        "id": "3fk1rL-aRiw",
         "description": "Private Key",
         "tags": [
           "group:leaktk-testing",
@@ -461,7 +461,7 @@ the Image, Config and Manifest.
 
 ```json
 {
-  "id": "1c7387179582ae1e9bc23123a10bddc6317fe6a5362efd2ae4019e34cccd8420",
+  "id": "GTykQmSnoio",
   "kind": "ContainerImage",
   "resource": "quay.io/leaktk/fake-leaks:v1.0.1"
 }
@@ -510,22 +510,22 @@ so not all images will have the information.
 #### Response
 ```json
 {
-  "id": "a1ef32d00c609b370d2181ea46b11111119deeeea68918cc676a8f12d1fc7e3b",
+  "id": "X71VJDDYKUc",
   "request": {
-    "id": "1c7387179582ae1e9bc23123a10bddc6317fe6a5362efd2ae4019e34cccd8420",
+    "id": "e6jlVhrbFBq",
     "kind": "ContainerImage",
     "resource": "quay.io/leaktk/fake-leaks:v1.0.1"
   },
   "results": [
     {
-      "id": "6c14f496a2111dfeecbfff4a61587b0b1866788a6112b420f80071f8cded0153",
+      "id": "1JYuHIigWRd",
       "kind": "ContainerLayer",
       "secret": "-----BEGIN PRIVATE KEY-----\n...snip...\n-----END PRIVATE KEY-----",
       "match": "-----BEGIN PRIVATE KEY-----\n...snip...\n-----END PRIVATE KEY-----",
       "entropy": 6.0285063,
       "date": "",
       "rule": {
-        "id": "private-key",
+        "id": "3fk1rL-aRiw",
         "description": "Private Key",
         "tags": [
           "group:leaktk-testing",

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -21,8 +21,8 @@ func TestScanCommandToRequest(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, request)
 
-	// ID should default to a random UUID
-	assert.Equal(t, 64, len(request.ID))
+	// ID should default to a random id
+	assert.Equal(t, 11, len(request.ID))
 	// Kind should default to GitRepo
 	assert.Equal(t, request.Resource.Kind(), "GitRepo")
 	assert.Equal(t, request.Resource.String(), "https://github.com/leaktk/fake-leaks.git")

--- a/examples/requests.jsonl
+++ b/examples/requests.jsonl
@@ -1,15 +1,15 @@
-{"id":"180efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"GitRepo",  "resource":"https://github.com/leaktk/fake-leaks.git"}
-{"id":"280efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"GitRepo",  "resource":"https://github.com/leaktk/fake-leaks.git","options":{"depth":5}}
-{"id":"380efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"GitRepo",  "resource":"https://github.com/leaktk/fake-leaks.git","options":{"since":"2020-01-01","branch":"main"}}
-{"id":"480efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"GitRepo",  "resource":"https://github.com/leaktk/not-a-real-repo.git"}
-{"id":"580efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"JSONData", "resource":"{\"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}"}
-{"id":"680efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"JSONData", "resource":"{\".gitleaks.toml\": \"[allowlist]\\nregexes = ['BEGIN PRIVATE KEY']\\n\", \"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}"}
-{"id":"780efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"Files",    "resource":"README.md"}
-{"id":"880efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"URL",      "resource":"https://raw.githubusercontent.com/leaktk/fake-leaks/main/general-test"}
-{"id":"1c7387111111ae1e9bc114bfa10bddc6317fe6a5362efd2ae4019e34cccd8420", "kind":"ContainerImage","resource":"quay.io/leaktk/fake-leaks:v1.0.1", "options": {"exclusions": ["2b84bab8609aea9706783cda5f66adb7648a7daedd2650665ca67c717718c3d1"]}}
-{"id":"6d25f1aa7c8d41c9f74a8cfd931007465d1406ce1f722965efcd250ccc605e27", "kind":"ContainerImage","resource":"quay.io/leaktk/fake-leaks:v1.0.1", "options": {"depth": 1}}
-{"id":"6fdabcb1883634bddb23878c944e0dbea444c8c853c7f10e55a552d8e0ac0a4d", "kind":"ContainerImage","resource":"quay.io/leaktk/fake-leaks:v1.0.1", "options": {"since": "2024-02-04"}}
-{"id":"324cbaba6d05a483a5501925daa0baf0fdf5cd204aac0af08c86ba661afeef2f", "kind":"ContainerImage","resource":"quay.io/jetstack/cert-manager-controller:v1.16.0"}
-{"kind": "GitRepo", "id": "low-priority", "resource": "https://github.com/leaktk/fake-leaks", "options": {"priority": 0}}
-{"kind": "GitRepo", "id": "high-priority", "resource": "https://github.com/leaktk/fake-leaks", "options": {"priority": 1}}
-{"id":"580efb11ee9013a42d6037566c7159c9aeb610696be851dc9209c85e75e5a3e7", "kind":"JSONData", "resource":"{\"url1\":\"https://notreal.co.asd\", \"url2\":\"http://www.google.com\", \"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}", "options": {"fetch_urls": "*"}}
+{"id":"qFd40DkKO-G", "kind":"GitRepo",        "resource":"https://github.com/leaktk/fake-leaks.git"}
+{"id":"ezRuxBiDDt-", "kind":"GitRepo",        "resource":"https://github.com/leaktk/fake-leaks.git","options":{"depth":5}}
+{"id":"AUcsemD1AjE", "kind":"GitRepo",        "resource":"https://github.com/leaktk/fake-leaks.git","options":{"since":"2020-01-01","branch":"main"}}
+{"id":"ZTfbdaufQzz", "kind":"GitRepo",        "resource":"https://github.com/leaktk/not-a-real-repo.git"}
+{"id":"G6cQ8gcqd26", "kind":"JSONData",       "resource":"{\"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}"}
+{"id":"1scwY0WF01D", "kind":"JSONData",       "resource":"{\".gitleaks.toml\": \"[allowlist]\\nregexes = ['BEGIN PRIVATE KEY']\\n\", \"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}"}
+{"id":"h5UEOsC_2Su", "kind":"Files",          "resource":"README.md"}
+{"id":"toSO-HdJWKK", "kind":"URL",            "resource":"https://raw.githubusercontent.com/leaktk/fake-leaks/main/general-test"}
+{"id":"sOLJAWnoUGo", "kind":"ContainerImage", "resource":"quay.io/leaktk/fake-leaks:v1.0.1", "options": {"exclusions": ["2b84bab8609aea9706783cda5f66adb7648a7daedd2650665ca67c717718c3d1"]}}
+{"id":"VkmQgpTcAyI", "kind":"ContainerImage", "resource":"quay.io/leaktk/fake-leaks:v1.0.1", "options": {"depth": 1}}
+{"id":"j1zjPQsiKEY", "kind":"ContainerImage", "resource":"quay.io/leaktk/fake-leaks:v1.0.1", "options": {"since": "2024-02-04"}}
+{"id":"cU17zc8y_IA", "kind":"ContainerImage", "resource":"quay.io/jetstack/cert-manager-controller:v1.16.0"}
+{"id":"low-prioz03", "kind": "GitRepo",       "resource": "https://github.com/leaktk/fake-leaks", "options": {"priority": 0}}
+{"id":"high-prioZ-", "kind": "GitRepo",       "resource": "https://github.com/leaktk/fake-leaks", "options": {"priority": 1}}
+{"id":"sXxdJdb1ic5", "kind":"JSONData",       "resource":"{\"url1\":\"https://notreal.co.asd\", \"url2\":\"http://www.google.com\", \"some\":{\"key\": \"-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----\"}}", "options": {"fetch_urls": "*"}}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.22.8
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/adrg/xdg v0.5.3
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/containers/image/v5 v5.34.0
-	github.com/google/uuid v1.6.0
 	github.com/h2non/filetype v1.1.3
 	github.com/klauspost/compress v1.17.11
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=

--- a/pkg/id/id.go
+++ b/pkg/id/id.go
@@ -1,23 +1,29 @@
 package id
 
 import (
-	"crypto/sha256"
-	"fmt"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
 	"strings"
 
-	"github.com/google/uuid"
+	"github.com/cespare/xxhash/v2"
+
+	"github.com/leaktk/scanner/pkg/logger"
 )
 
 // ID returns an unique ID based on the parts passed in. If none are passed in
-// then ID will be random. The ID will be a fixed length hexadecimal characters.
+// then ID will be random. The ID will be a fixed length characters.
 func ID(parts ...string) string {
-	var data []byte
+	data := make([]byte, 8)
 
 	if len(parts) > 0 {
-		data = []byte(strings.Join(parts, "\n"))
+		hash := xxhash.Sum64String(strings.Join(parts, "\n"))
+		binary.BigEndian.PutUint64(data, hash)
 	} else {
-		data = []byte(uuid.New().String())
+		if _, err := rand.Read(data); err != nil {
+			logger.Fatal("could not generate random id: error=%q", err)
+		}
 	}
 
-	return fmt.Sprintf("%x", sha256.Sum256(data))
+	return base64.RawURLEncoding.EncodeToString(data)
 }

--- a/pkg/id/id_test.go
+++ b/pkg/id/id_test.go
@@ -13,16 +13,16 @@ func TestID(t *testing.T) {
 	})
 
 	t.Run("IDsAreSameLength", func(t *testing.T) {
-		assert.Equal(t, 64, len(ID()))
-		assert.Equal(t, 64, len(ID("foo")))
-		assert.Equal(t, 64, len(ID("foo", "bar")))
+		assert.Equal(t, 11, len(ID()))
+		assert.Equal(t, 11, len(ID("foo")))
+		assert.Equal(t, 11, len(ID("foo", "bar")))
 	})
 
 	t.Run("IDsAreHexadecimal", func(t *testing.T) {
 		// Run the test a bunch of times on random and parameterized ID calls
 		for i := 0; i < 100; i++ {
-			assert.Regexp(t, "^[0-9a-f]+$", ID())
-			assert.Regexp(t, "^[0-9a-f]+$", ID(strconv.Itoa(i), ID()))
+			assert.Regexp(t, `^[\w-]+$`, ID())
+			assert.Regexp(t, `^[\w-]+$`, ID(strconv.Itoa(i), ID()))
 		}
 	})
 }


### PR DESCRIPTION
Change:

- Use xxhash and crypto/rand for ID creation
- Remove google/uuid lib
- Update IDs in docs
- Change from hex to base64url 

Reason:

- Faster hashing
- Faster rand id creation
- Keep the docs matching the code
- base64url is shorter than hex and should be safe in FS paths

How to create a random one from the command line:

```
openssl rand 8 | basenc --base64url | sed -s 's/=//g' | tr -d '\n'
```

After this:

- We'll want to update the IDs in the patterns. It shouldn't be too hard to grep for them and do a script to search and replace with a new random ID generated using the script above.