### PR TITLE
Build, Sign and release binaries & containers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Protect CODEOWNERS and GitHub Actions
+/.github/ @bplaxco @thewizzy @abutcher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Build, sign and upload release artifacts
 
 env:
-  GO_VERSION: ${{ env.GO_VERSION }}
+  GO_VERSION: '1.22'
   GO111MODULE: on
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: goreleaser
+name: Build, sign and upload release artifacts
 
 env:
   GO_VERSION: '1.22'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5
         with:
-          go-version: stable
+          go-version: ${{ env.GO_VERSION }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pin@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Build, sign and upload release artifacts
 
 env:
-  GO_VERSION: '1.22'
+  GO_VERSION: ${{ env.GO_VERSION }}
   GO111MODULE: on
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ env:
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-1].[0-9]+.[0-9]+"
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: goreleaser
+
+env:
+  GO_VERSION: '1.22'
+  GO111MODULE: on
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
+jobs:
+  tests:
+    uses: ./.github/workflows/testing.yml
+
+  goreleaser:
+    name: Create release artifacts
+    needs: [ tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5
+        with:
+          go-version: stable
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pin@v3
+        with:
+          registry: quay.io
+          username: ${{ vars.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # pin@v3
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # pin@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ leaktk-scanner
 
 # Go workspace file
 go.work
+# Added by goreleaser init:
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,8 +17,8 @@ builds:
 archives:
   - formats: tar.xz
     name_template: >-
-      {{ .ProjectName }}-
-      {{ .Version }}-
+      leaktk-{{ .ProjectName }}-
+      {{- .Version }}-
       {{- .Os }}-
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,7 +45,7 @@ changelog:
 
 dockers:
   - image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
     use: buildx
     dockerfile: Containerfile
     build_flag_templates:
@@ -57,12 +57,12 @@ dockers:
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
   - image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
     use: buildx
     goarch: arm64
     dockerfile: Containerfile
     build_flag_templates:
-      - --platform=linux/arm64/v8
+      - --platform=linux/arm64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.version={{ .Version }}
@@ -70,14 +70,22 @@ dockers:
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
 docker_manifests:
-  - name_template: "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}"
+  - name_template: "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}"
     image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
-      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
+  - name_template: "quay.io/leaktk/{{ .ProjectName }}:v{{ .Major }}"
+    image_templates:
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
+  - name_template: "quay.io/leaktk/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
   - name_template: "quay.io/leaktk/{{ .ProjectName }}:latest"
     image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
-      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
 
 docker_signs:
   - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,103 @@
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - binary: scanner
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -X github.com/leaktk/scanner/cmd.Version={{.Version}} -X github.com/leaktk/scanner/cmd.Commit={{.Commit}}
+
+archives:
+  - formats: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+dockers:
+  - image_templates:
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: Containerfile
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=MIT
+  - image_templates:
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
+    use: buildx
+    goarch: arm64
+    dockerfile: Containerfile
+    build_flag_templates:
+      - --platform=linux/arm64/v8
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=MIT
+docker_manifests:
+  - name_template: "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}"
+    image_templates:
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
+  - name_template: "quay.io/leaktk/{{ .ProjectName }}:latest"
+    image_templates:
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
+
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    output: true
+    args:
+      - "sign"
+      - "${artifact}"
+      - "--yes"
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - '--oidc-provider=github-actions'
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+      - --yes
+    artifacts: all
+    output: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ before:
     - go generate ./...
 
 builds:
-  - binary: scanner
+  - binary: leaktk-{{ .ProjectName }}
     env:
       - CGO_ENABLED=0
     goos:
@@ -19,7 +19,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -X github.com/leaktk/scanner/cmd.Version={{.Version}} -X github.com/leaktk/scanner/cmd.Commit={{.Commit}}
+      - -X github.com/leaktk/scanner/cmd.Version={{ .Version }} -X github.com/leaktk/scanner/cmd.Commit={{ .FullCommit }}
 
 archives:
   - formats: tar.gz
@@ -63,7 +63,7 @@ dockers:
     dockerfile: Containerfile
     build_flag_templates:
       - --platform=linux/arm64
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.title=leaktk-{{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
@@ -100,6 +100,8 @@ signs:
   - cmd: cosign
     signature: "${artifact}.sig"
     certificate: "${artifact}.pem"
+    artifacts: all
+    output: true
     args:
       - sign-blob
       - '--oidc-provider=github-actions'
@@ -107,5 +109,3 @@ signs:
       - '--output-signature=${signature}'
       - '${artifact}'
       - --yes
-    artifacts: all
-    output: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,12 +1,5 @@
 version: 2
 
-before:
-  hooks:
-    # You may remove this if you don't use go modules.
-    - go mod tidy
-    # you may remove this if you don't need go generate
-    - go generate ./...
-
 builds:
   - binary: leaktk-{{ .ProjectName }}
     env:
@@ -22,15 +15,14 @@ builds:
       - -X github.com/leaktk/scanner/cmd.Version={{ .Version }} -X github.com/leaktk/scanner/cmd.Commit={{ .FullCommit }}
 
 archives:
-  - formats: tar.gz
-    # this name template makes the OS and Arch compatible with the results of `uname`.
+  - formats: tar.xz
     name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
+      {{ .ProjectName }}-
+      {{ .Version }}-
+      {{- .Os }}-
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:
       - goos: windows
@@ -45,47 +37,49 @@ changelog:
 
 dockers:
   - image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
     use: buildx
     dockerfile: Containerfile
     build_flag_templates:
       - --platform=linux/amd64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.description="The secrets scanner from the LeakTK project"
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.source={{ .GitURL }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
   - image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
     use: buildx
     goarch: arm64
     dockerfile: Containerfile
     build_flag_templates:
       - --platform=linux/arm64
       - --label=org.opencontainers.image.title=leaktk-{{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.description="The secrets scanner from the LeakTK project"
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.source={{ .GitURL }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
 docker_manifests:
-  - name_template: "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}"
+  - name_template: "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}"
     image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
-  - name_template: "quay.io/leaktk/{{ .ProjectName }}:v{{ .Major }}"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
+  - name_template: "quay.io/leaktk/{{ .ProjectName }}:{{ .Major }}"
     image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
-  - name_template: "quay.io/leaktk/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
+  - name_template: "quay.io/leaktk/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
   - name_template: "quay.io/leaktk/{{ .ProjectName }}:latest"
     image_templates:
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-amd64"
-      - "quay.io/leaktk/{{ .ProjectName }}:v{{ .Version }}-arm64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "quay.io/leaktk/{{ .ProjectName }}:{{ .Version }}-arm64"
 
 docker_signs:
   - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,7 +42,7 @@ dockers:
     dockerfile: Containerfile
     build_flag_templates:
       - --platform=linux/amd64
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.title=leaktk-{{ .ProjectName }}
       - --label=org.opencontainers.image.description="The secrets scanner from the LeakTK project"
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY scanner /usr/local/bin/scanner
+ENTRYPOINT ["/usr/local/bin/scanner"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,3 @@
 FROM scratch
-COPY scanner /usr/local/bin/scanner
-ENTRYPOINT ["/usr/local/bin/scanner"]
+COPY leaktk-scanner /usr/local/bin/leaktk-scanner
+ENTRYPOINT ["/usr/local/bin/leaktk-scanner"]


### PR DESCRIPTION
Uses goreleaser to automatically do the following when a new `v*` tag is created:
- Build 
- Sign builds
- Create containers
- Sign contains
- Upload artifacts to github and quay.io (containers)

Resolves #85 