### PR TITLE
Don't create config/cache dirs until needed

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/adrg/xdg"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,7 +59,7 @@ func TestPartialLoadConfigFromFile(t *testing.T) {
 
 func TestLocateAndLoadConfig(t *testing.T) {
 	// Set the env var here to prove the provided path overrides it
-	xdg.ConfigHome = "../../testdata/locator-test"
+	localConfigDir = "../../testdata/locator-test/leaktk"
 	os.Setenv("LEAKTK_CONFIG_PATH", "../../testdata/locator-test/leaktk/config.2.toml")
 
 	// Confirm load from file works


### PR DESCRIPTION
This fixes an issue where you can get messages like:

```
could not create dir: path="/.cache/leaktk"
```

When you run leaktk-scanner as a subprocess, are passing in a specific workdir from the config and HOME isn't set. Before it would try to create ~/.cache/leaktk first, even if that's not where the cache dir was configured to be.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED