### PR TITLE
Auto set version based on tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.0.1
+VERSION := $(shell ./hack/version)
 COMMIT := $(shell git rev-parse HEAD)
 BUILD_META :=
 BUILD_META += -X=github.com/leaktk/scanner/cmd.Version=$(VERSION)

--- a/hack/version
+++ b/hack/version
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+last_version="$(git tag --sort=-v:refname | grep -P '^v\d+\.\d+\.\d+$' | head -n 1 | sed 's/v//g')"
+extra_commits="$(git rev-list "v${last_version}..HEAD" --count)"
+
+if [[ "${extra_commits}" -eq 0 ]]
+then
+  echo "${last_version}"
+else
+  echo "${last_version}+${extra_commits}-commits"
+fi


### PR DESCRIPTION
Set the version based on the last tag in the history:

If the last tag isn't the current commit it does this:

```
$ ./leaktk-scanner version
Version: 0.0.14+12-commits
Commit: 675c38d690fdc51b7c55be76ebe395034d8cb288
```