### PR TITLE
Include gitleaks fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ leaktk-scanner listen < ./examples/requests.jsonl
 # Run a single scan
 leaktk-scanner scan --resource 'https://github.com/leaktk/fake-leaks.git'
 leaktk-scanner scan --kind JSONData --resource '{"key": "-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----"}'
+leaktk-scanner scan --kind JSONData --resource '@/path/to/some-file.json'
 
 # See more options
 leaktk-scanner help

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/leaktk/scanner/pkg/config"
+	"github.com/leaktk/scanner/pkg/fs"
 	"github.com/leaktk/scanner/pkg/id"
 	"github.com/leaktk/scanner/pkg/logger"
 	"github.com/leaktk/scanner/pkg/scanner"
@@ -122,6 +123,19 @@ func scanCommandToRequest(cmd *cobra.Command) (*scanner.Request, error) {
 	resource, err := flags.GetString("resource")
 	if err != nil || len(resource) == 0 {
 		return nil, errors.New("missing required field: field=\"resource\"")
+	}
+
+	if resource[0] == '@' {
+		if fs.FileExists(resource[1:]) {
+			data, err := os.ReadFile(resource[1:])
+			if err != nil {
+				return nil, fmt.Errorf("could not read resource: path=%q error=%q", resource[1:], err)
+			}
+
+			resource = string(data)
+		} else {
+			return nil, fmt.Errorf("resource path does not exist: path=%q", resource[1:])
+		}
 	}
 
 	rawOptions, err := flags.GetString("options")

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/leaktk/scanner/pkg/fs"
 )
 
 func TestScanCommandToRequest(t *testing.T) {
@@ -12,13 +16,13 @@ func TestScanCommandToRequest(t *testing.T) {
 	// Resource must be set
 	request, err := scanCommandToRequest(cmd)
 	assert.Nil(t, request)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "missing required field: field=\"resource\"")
 
 	// Setting resource for the rest of the tests
 	_ = cmd.Flags().Set("resource", "https://github.com/leaktk/fake-leaks.git")
 	request, err = scanCommandToRequest(cmd)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, request)
 
 	// ID should default to a random id
@@ -26,4 +30,25 @@ func TestScanCommandToRequest(t *testing.T) {
 	// Kind should default to GitRepo
 	assert.Equal(t, request.Resource.Kind(), "GitRepo")
 	assert.Equal(t, request.Resource.String(), "https://github.com/leaktk/fake-leaks.git")
+
+	// If resource starts with @ and the thing is a valid path, resource will be loaded from there
+	tmpDir := t.TempDir()
+	data_path, err := fs.CleanJoin(tmpDir, "data.json")
+	assert.NoError(t, err)
+	err = os.WriteFile(data_path, []byte("{\"some\": \"data\"}"), 0600)
+	assert.NoError(t, err)
+
+	_ = cmd.Flags().Set("resource", "@"+data_path)
+	_ = cmd.Flags().Set("kind", "JSONData")
+	request, err = scanCommandToRequest(cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, request.Resource.Kind(), "JSONData")
+	assert.Equal(t, request.Resource.String(), "{\"some\": \"data\"}")
+
+	// If resource starts with @ and the thing is an invalid path, raise an error
+	_ = cmd.Flags().Set("resource", "@"+data_path+".invalid")
+	request, err = scanCommandToRequest(cmd)
+	assert.Error(t, err)
+	assert.Nil(t, request)
+	assert.Equal(t, err.Error(), fmt.Sprintf("resource path does not exist: path=%q", data_path+".invalid"))
 }

--- a/pkg/scanner/gitleaks.go
+++ b/pkg/scanner/gitleaks.go
@@ -212,6 +212,7 @@ func (g *Gitleaks) Scan(scanResource resource.Resource) ([]*response.Result, err
 		switch scanResource.(type) {
 		case *resource.GitRepo:
 			notes["message"] = finding.Message
+			notes["gitleaks_fingerprint"] = finding.Fingerprint
 		}
 
 		result := &response.Result{

--- a/pkg/scanner/gitleaks_test.go
+++ b/pkg/scanner/gitleaks_test.go
@@ -53,6 +53,8 @@ func TestGitleaksScan(t *testing.T) {
 		results, err := NewGitleaks(1, patterns).Scan(gitRepo)
 		assert.NoError(t, err)
 		assert.Greater(t, len(results), 0)
+		// This should at least be defined on git responses
+		assert.Contains(t, results[0].Notes["gitleaks_fingerprint"], ":test-rule:")
 		assert.Equal(t, results[0].Rule.ID, "test-rule")
 		assert.Equal(t, strings.ToLower(results[0].Secret), "fake")
 	})


### PR DESCRIPTION
Handy for if you need to write a .gitleaksignore for your repo. 

**Alt Idea**

(WIP: considering just creating a fingerprint field on the result object and passing it through but that depends on how stable it is in gitleaks and if we want to tie into that same format).

Review this after https://github.com/leaktk/scanner/pull/105 is merged.