### PR TITLE
Return a LeakExitCode when a leak is found on a single scan

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -184,9 +184,10 @@ func scanCommandToRequest(cmd *cobra.Command) (*scanner.Request, error) {
 
 func scanCommand() *cobra.Command {
 	scanCommand := &cobra.Command{
-		Use:   "scan",
-		Short: "Perform ad-hoc scans",
-		RunE:  runScan,
+		Use:          "scan",
+		Short:        "Perform ad-hoc scans",
+		RunE:         runScan,
+		SilenceUsage: true,
 	}
 
 	flags := scanCommand.Flags()

--- a/pkg/config/exit_codes.go
+++ b/pkg/config/exit_codes.go
@@ -4,3 +4,6 @@ package config
 // inoperable. For example, the config is broken or it can't pull patterns
 // for the first time.
 const ExitCodeBlockingError = 1
+
+// LeakExitCode is returned when a scan returns results
+const LeakExitCode = 42


### PR DESCRIPTION
This is useful for automation, especially where we do not want to consume and redisplay the whole program out.

We could set this as a command line option too, like gitleaks does, if deemed necessary?