### PR TITLE
Changes to support scanning "staging" for precommit

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -184,9 +184,10 @@ func scanCommandToRequest(cmd *cobra.Command) (*scanner.Request, error) {
 
 func scanCommand() *cobra.Command {
 	scanCommand := &cobra.Command{
-		Use:   "scan",
-		Short: "Perform ad-hoc scans",
-		RunE:  runScan,
+		Use:          "scan",
+		Short:        "Perform ad-hoc scans",
+		RunE:         runScan,
+		SilenceUsage: true,
 	}
 
 	flags := scanCommand.Flags()

--- a/pkg/config/exit_codes.go
+++ b/pkg/config/exit_codes.go
@@ -4,3 +4,6 @@ package config
 // inoperable. For example, the config is broken or it can't pull patterns
 // for the first time.
 const ExitCodeBlockingError = 1
+
+// LeakExitCode is returned when a scan returns results
+const LeakExitCode = 42

--- a/pkg/resource/git.go
+++ b/pkg/resource/git.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/leaktk/scanner/pkg/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,6 +76,12 @@ func (r *GitRepo) String() string {
 // Clone the resource to the desired local location and store the path
 func (r *GitRepo) Clone(path string) error {
 	r.clonePath = path
+
+	// If we are passed a folder with a .git subfolder set it as the clonePath
+	if fs.PathExists(r.cloneURL) && fs.PathExists(filepath.Join(r.cloneURL, ".git")) {
+		r.clonePath = r.cloneURL
+		return nil
+	}
 
 	cloneArgs := []string{"clone"}
 

--- a/pkg/resource/git.go
+++ b/pkg/resource/git.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/leaktk/scanner/pkg/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/leaktk/scanner/pkg/fs"
 
 	"github.com/leaktk/scanner/pkg/response"
 
@@ -42,6 +43,8 @@ type GitRepoOptions struct {
 	Proxy string `json:"proxy"`
 	// The scan priority
 	Priority int `json:"priority"`
+	// Scan staging only
+	Staged bool `json:"staged"`
 }
 
 // GitRepo provides a way to interact with a git repo
@@ -180,6 +183,11 @@ func (r *GitRepo) SetCloneTimeout(timeout time.Duration) {
 // that have versions
 func (r *GitRepo) Since() string {
 	return r.options.Since
+}
+
+// Staged returns whether to scan staged only
+func (r *GitRepo) Staged() bool {
+	return r.options.Staged
 }
 
 // ReadFile provides a way to get files out of the repo

--- a/pkg/scanner/gitleaks.go
+++ b/pkg/scanner/gitleaks.go
@@ -97,7 +97,6 @@ func (g *Gitleaks) newDetector(scanResource resource.Resource) (*detect.Detector
 
 // gitScan handles when the resource is a gitRepo type
 func (g *Gitleaks) gitScan(detector *detect.Detector, gitRepo *resource.GitRepo) ([]report.Finding, error) {
-	staged := true
 	gitLogOpts := []string{"--full-history", "--ignore-missing"}
 
 	if len(gitRepo.Since()) > 0 {
@@ -125,7 +124,7 @@ func (g *Gitleaks) gitScan(detector *detect.Detector, gitRepo *resource.GitRepo)
 		gitCmd *sources.GitCmd
 		err    error
 	)
-	if staged {
+	if gitRepo.Staged() {
 		gitCmd, err = sources.NewGitDiffCmd(gitRepo.ClonePath(), true)
 	} else {
 		gitCmd, err = sources.NewGitLogCmd(gitRepo.ClonePath(), strings.Join(gitLogOpts, " "))


### PR DESCRIPTION
This PR brings in:
* Return exit code 42 on exit if there are leaks found
* Adds support for local git repos. Checks if the path exists and it contains a .git folder. (I think will need to check this against worktrees)
* Adds the gitrepo option `"staged": bool` this changes feed for the detector from git log to a git diff --staged. 

Outstanding / Feedback required:
* Need to pass redact through to the detector. The easiest way is to add this to the options for all types, and this would support redaction when running in listen. Another option, or alongside, is being able to specify it with --redact when running scanner. Adding to options seems clunky if you want to run single scans on the command line. Thoughts?
* Test and modify local git repo check to support worktrees.