### PR TITLE
Improve fetch URLs logging

### DIFF
--- a/pkg/resource/json_data.go
+++ b/pkg/resource/json_data.go
@@ -124,11 +124,12 @@ func (r *JSONData) fetchURLs(rootNode jsonNode, clonePath string) error {
 		}
 
 		if !r.shouldFetchURL(leafNode.path) {
-			logger.Debug("not fetching URL: path=%q url=%q", leafNode.path, obj)
+			r.Debug(logger.CloneDetail, "not fetching URL: path=%q url=%q", leafNode.path, obj)
 			return nil
 		}
 
 		urlResource := NewURL(obj, &URLOptions{})
+		r.Info(logger.CloneDetail, "fetching url: url=%q", obj)
 		err := urlResource.Clone(filepath.Join(clonePath, leafNode.path))
 
 		if err != nil {
@@ -138,6 +139,7 @@ func (r *JSONData) fetchURLs(rootNode jsonNode, clonePath string) error {
 			return nil
 		}
 
+		r.Info(logger.CloneDetail, "replacing url with contents: path=%q url=%q", leafNode.path, obj)
 		return r.replaceWithResource(leafNode, urlResource)
 	})
 }


### PR DESCRIPTION
Example:

```
$ ./leaktk-scanner scan --kind JSONData --resource '{"data": {"url": "https://example.com"}}' --options '{"fetch_urls": "**"}'
[INFO] queueing clone: request_id="eDPYnpae6sg" resource_id="jFYRWQuRZ2A"
[INFO] starting clone: request_id="eDPYnpae6sg" resource_id="jFYRWQuRZ2A"
[INFO] resource_id=jFYRWQuRZ2A fetching url: url="https://example.com"
[INFO] resource_id=jFYRWQuRZ2A replacing url with contents: path="data/url" url="https://example.com"
[INFO] queueing scan: request_id="eDPYnpae6sg" resource_id="jFYRWQuRZ2A"
[INFO] starting scan: request_id="eDPYnpae6sg" resource_id="jFYRWQuRZ2A" scanner_backend="Gitleaks"
[INFO] updated gitleaks patterns: hash=ae83bf0b0a190548bbebbe71d9db2270d5ab0a9548072a00b49c574fa9761277
[INFO] queueing response: request_id="eDPYnpae6sg" resource_id="jFYRWQuRZ2A"
{"id":"wlqPGxIY9Tg","logs":null,"request_id":"eDPYnpae6sg","results":[]}
```

Specifically:

```
...
[INFO] resource_id=jFYRWQuRZ2A fetching url: url="https://example.com"
[INFO] resource_id=jFYRWQuRZ2A replacing url with contents: path="data/url" url="https://example.com"
...
```
