### PR TITLE
Implement custom useragent

### DIFF
--- a/cmd/useragent.go
+++ b/cmd/useragent.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+)
+
+// globalUserAgent is the useragent used by default by http
+var globalUserAgent = fmt.Sprintf("leaktk-scanner/%s (%s %s)", shortVersion(), runtime.GOOS, runtime.GOARCH)
+
+type userAgentTransport struct {
+	rt http.RoundTripper
+}
+
+func (uat *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("User-Agent", globalUserAgent)
+	return uat.rt.RoundTrip(req)
+}
+
+func init() {
+	http.DefaultTransport = &userAgentTransport{
+		rt: http.DefaultTransport,
+	}
+}
+
+func shortVersion() string {
+	if len(Version) > 0 {
+		if len(Commit) > 0 {
+			return Version + "@" + Commit
+		}
+		return Version
+	}
+	return "unknown"
+}

--- a/pkg/resource/container_image.go
+++ b/pkg/resource/container_image.go
@@ -136,7 +136,9 @@ func (r *ContainerImage) Clone(path string) error {
 
 // cloneRemoteResource clones a remote resource ready for scanning.
 func (r *ContainerImage) cloneRemoteResource(ctx context.Context, path string, resource string) error {
-	sysCtx := &types.SystemContext{}
+	sysCtx := &types.SystemContext{
+		DockerRegistryUserAgent: "leaktk-scanner/version@commit (os arch)",
+	}
 
 	imgRef, err := docker.ParseReference("//" + resource)
 	if err != nil {


### PR DESCRIPTION
This will override all http library user agents as long as they are using the http.DefaultTransport.

There is a way to set the container images library useragent (see pkg/resource/container_image.go). I am just trying to work out how to go from where we are to having it in the container_image file too. It is close to cmd because it uses version and commit from there. 

Example user-agent `leaktk-scanner/0.0.17@12312312 (linux amd64)`.

Implements #129 