### PR TITLE
Avoid a panic when resource is empty

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -154,7 +154,7 @@ func scanCommandToRequest(cmd *cobra.Command, args []string) (*proto.Request, er
 		return nil, errors.New("missing required field: field=\"kind\"")
 	}
 
-	if len(args) == 0 {
+	if len(args) == 0 || len(args[0]) == 0 {
 		return nil, errors.New("missing required field: field=\"resource\"")
 	}
 


### PR DESCRIPTION
Fixes a go panic for this case:

```
leaktk scan ""
```

That can happen if you template out the resource from something else in your shell and your cmd fails and doesn't provide any output which results in an empty resource and can cause the program to panic.

After the fix you get a log like this:

```
[CRITICAL] could not generate scan request: missing required field: field="resource"
```