### PR TITLE
perf: eliminate JSON processing overhead in scan command

### DIFF
--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -50,6 +50,12 @@ var requestKindNameMap = map[string]RequestKind{
 	"URL":            URLRequestKind,
 }
 
+// GetRequestKind converts a string to RequestKind enum
+func GetRequestKind(kind string) (RequestKind, bool) {
+	requestKind, exists := requestKindNameMap[kind]
+	return requestKind, exists
+}
+
 // Request is a request to LeakTK
 type Request struct {
 	ID       string      `json:"id"       toml:"id"       yaml:"id"`


### PR DESCRIPTION
Fix wasteful marshal→unmarshal→unmarshal roundtrip in scanCommandToRequest() that was causing 60% performance penalty when using -o options.

Changes:
- Replace JSON roundtrip with direct proto.Request struct creation
- Parse options directly into proto.Opts instead of map[string]any
- Add proto.GetRequestKind() helper for string-to-enum conversion
- Maintain all existing functionality and validation logic

Performance improvement:
- Before: 67+ seconds with JSON options vs 42s baseline (60% penalty)
- After: ~37 seconds with JSON options (no penalty)

The fix eliminates unnecessary JSON marshal/unmarshal operations while preserving the same request validation and option processing behavior.

Debug-and-Written-by: Claude code
Signed-off-by: Don Zickus <dzickus@redhat.com>