### PR TITLE
`leaktk hook git.*` commands

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Test
         run: go test -v ./...
 
+      - name: Intgration test - Linux only
+        if: startsWith(runner.os, 'Linux')
+        run: |
+          bash ./hack/integrationtest
+
   golangci-lint:
     name: Running linting on ubuntu-latest
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # Binaries for programs and plugins
-leaktk
-!completions/bash/leaktk
+/leaktk
 *.exe
-*.exe~
 *.dll
 *.so
 *.dylib
@@ -15,5 +13,10 @@ leaktk
 
 # Go workspace file
 go.work
+
 # Added by goreleaser init:
 dist/
+
+# Editor files
+*~
+*.swp

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,4 +1,5 @@
 [allowlist]
   paths = [
     '''_test.go$''',
+    '''docs/findings.md''',
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,20 @@ The tool operates in two modes:
 - **scan**: Ad-hoc scanning with human-readable or structured output
 - **listen**: Long-running server mode that reads JSONL requests from stdin and writes JSONL responses to stdout (logs go to stderr)
 
+## Development Philosophy
+
+When working on this codebase, approach development as a senior engineer who values pragmatism and clarity:
+
+- **Simplicity First**: Write simple, solid code that solves the problem at hand. Prefer straightforward solutions over clever ones.
+- **Data-Oriented Design**: Follow data-oriented design principles. Let data structures and their transformations guide your architecture.
+- **Test Your Work**: Write tests for your code. Tests document behavior and prevent regressions.
+- **Avoid Premature Abstraction**: Don't add abstractions until you have concrete evidence they're needed. Three instances of similar code don't necessarily need a shared abstraction.
+- **Well-Architected, Not Over-Architected**: Design clean interfaces and logical module boundaries, but don't build speculative flexibility for hypothetical future requirements.
+- **Let the Linter Guide You**: Run `make lint` regularly to catch issues and guide your style. The linter enforces team standards.
+- **Document User-Facing Changes**: Update documentation when making changes that affect users. Keep docs in sync with reality.
+- **Iterate on Refactoring**: When you finish implementing a feature, review it for refactoring opportunities. Clean up duplication, awkward interfaces, and unclear naming. Then review again. Repeat until the code feels right and there's nothing obvious left to improve.
+- **Comments With Purpose**: Add comments where the linter requires them and where they genuinely aid understanding. But strive to write code that's clear enough through good naming and simple logic that comments aren't always necessary.
+
 ## Development Commands
 
 ### Building

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,7 @@ vet:
 lint: vet
 	golangci-lint run
 
-build: import
-	CGO_ENABLED=0 go build $(LDFLAGS)
-
-build-pipe: 
+build:
 	CGO_ENABLED=0 go build $(LDFLAGS)
 
 import:
@@ -48,7 +45,7 @@ import:
 
 format: import
 	go fmt ./...
-	find . -type f \( -name '*.md' -or -name '*.go' \) | xargs sed -i 's/[ \t]*$$//g'
+	find . -type f \( -name '*.md' -or -name '*.go' -or -name Makefile \) | xargs sed -i 's/[ \t]*$$//g'
 
 test: format vet lint
 	go test -race $(MODULE) ./...

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ lint: vet
 build: import
 	CGO_ENABLED=0 go build $(LDFLAGS)
 
+build-pipe: 
+	CGO_ENABLED=0 go build $(LDFLAGS)
+
 import:
 	goimports -local $(MODULE) -l -w .
 	go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ import:
 
 format: import
 	go fmt ./...
-	find . -type f \( -name '*.md' -or -name '*.go' -or -name Makefile \) | xargs sed -i 's/[ \t]*$$//g'
+	find . -type f \( -name '*.md' -or -name '*.go' -or -name Makefile -or -path './hack/*' \) | xargs sed -i 's/[ \t]*$$//g'
 
 test: format vet lint
 	go test -race $(MODULE) ./...

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ import:
 
 format: import
 	go fmt ./...
+	find . -type f \( -name '*.md' -or -name '*.go' \) | xargs sed -i 's/[ \t]*$$//g'
 
 test: format vet lint
 	go test -race $(MODULE) ./...
@@ -53,7 +54,7 @@ failfast:
 	go test -failfast github.com/leaktk/leaktk ./...
 
 install:
-	install ./leaktk $(DESTDIR)$(PREFIX)/bin/leaktk
+	install -D ./leaktk $(DESTDIR)$(PREFIX)/bin/leaktk
 
 .PHONY: install.completions
 install.completions:

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ request even if there were errors. More info on the formats are in the
 
 ## Docs by Topic
 
-- [Installation](./docs/install.md)
-- [Scanning](./docs/scan.md)
-- [Configuration](./docs/config.md)
-- [Request/Response Formats for Listen](./listen.md)
-- (Coming Soon) Monitoring Sources
+- [Installation](docs/install.md)
+- [Scanning](docs/scan.md)
+- [Configuration](docs/config.md)
+- [Request/Response Formats for Listen](docs/listen.md)
+- [Git Hooks](docs/hooks.md)
 - (Coming Soon) Analyzing Results
-- (Coming Soon) Git Hook Setup
+- (Coming Soon) Monitoring Sources
 
 ## Project Status
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 
@@ -15,6 +16,7 @@ import (
 
 	"github.com/leaktk/leaktk/pkg/config"
 	"github.com/leaktk/leaktk/pkg/fs"
+	"github.com/leaktk/leaktk/pkg/hooks"
 	"github.com/leaktk/leaktk/pkg/id"
 	"github.com/leaktk/leaktk/pkg/logger"
 	"github.com/leaktk/leaktk/pkg/proto"
@@ -87,7 +89,7 @@ func runScan(cmd *cobra.Command, args []string) {
 
 	gitleaksConfig, err := cmd.Flags().GetString("gitleaks-config")
 	if err != nil {
-		logger.Fatal("invalid gitleaks-config: error=%q", err.Error())
+		logger.Fatal("invalid gitleaks-config: %v", err.Error())
 	}
 
 	// Providing a gitleaks-config via command line arguments takes
@@ -163,7 +165,7 @@ func scanCommandToRequest(cmd *cobra.Command, args []string) (*proto.Request, er
 		if fs.FileExists(requestResource[1:]) {
 			data, err := os.ReadFile(requestResource[1:])
 			if err != nil {
-				return nil, fmt.Errorf("could not read resource: path=%q error=%q", requestResource[1:], err)
+				return nil, fmt.Errorf("could not read resource: %w path=%q", err, requestResource[1:])
 			}
 
 			requestResource = string(data)
@@ -174,7 +176,7 @@ func scanCommandToRequest(cmd *cobra.Command, args []string) (*proto.Request, er
 
 	rawOpts, err := flags.GetString("options")
 	if err != nil {
-		return nil, fmt.Errorf("there was an issue with the options flag: error=%q", err)
+		return nil, fmt.Errorf("there was an issue with the options flag: %w", err)
 	}
 
 	// Convert kind string to enum
@@ -187,7 +189,7 @@ func scanCommandToRequest(cmd *cobra.Command, args []string) (*proto.Request, er
 	var opts proto.Opts
 	if rawOpts != "{}" && len(rawOpts) > 0 {
 		if err := json.Unmarshal([]byte(rawOpts), &opts); err != nil {
-			return nil, fmt.Errorf("could not parse options: error=%q", err)
+			return nil, fmt.Errorf("could not parse options: %w", err)
 		}
 	}
 
@@ -207,6 +209,37 @@ func scanCommandToRequest(cmd *cobra.Command, args []string) (*proto.Request, er
 	return request, nil
 }
 
+func runHook(cmd *cobra.Command, args []string) {
+	hookname := args[0]
+	hook := hooks.Hook(hookname)
+
+	if !slices.Contains(cmd.ValidArgs, hookname) {
+		logger.Fatal("invalid hookname: hookname=%q", hookname)
+	}
+
+	statusCode, err := hooks.Run(cfg, hook, args[1:])
+	if err != nil {
+		logger.Fatal("error running hook: %v hookname=%q", err, hookname)
+	}
+
+	os.Exit(statusCode)
+}
+
+func hookCommand() *cobra.Command {
+	validArgs := make([]string, len(hooks.Hooks))
+	for i, hook := range hooks.Hooks {
+		validArgs[i] = hook.Name()
+	}
+
+	return &cobra.Command{
+		Use:       "hook [flags] <hookname> [hookargs]...",
+		Short:     "Hook leaktk into existng workflows",
+		Args:      cobra.MinimumNArgs(1),
+		ValidArgs: validArgs,
+		Run:       runHook,
+	}
+}
+
 func scanCommand() *cobra.Command {
 	scanCommand := &cobra.Command{
 		Use:                   "scan [flags] <resource>",
@@ -217,11 +250,11 @@ func scanCommand() *cobra.Command {
 	}
 
 	flags := scanCommand.Flags()
-	flags.String("id", id.ID(), "an ID for associating responses to requests")
-	flags.StringP("kind", "k", "GitRepo", "the kind of resource to scan")
-	flags.StringP("options", "o", "{}", "additional request options formatted as JSON")
-	flags.Int("leak-exit-code", 0, "the exit code when leaks are found (default 0)")
-	flags.String("gitleaks-config", "", "the path to a custom gitleaks config")
+	flags.String("id", id.ID(), "Set the ID request ID that will be displayed in the response and logs")
+	flags.StringP("kind", "k", "GitRepo", "Specify the kind of resource being scanned")
+	flags.StringP("options", "o", "{}", "Provide scan specific options formatted as JSON")
+	flags.Int("leak-exit-code", 0, "Exit with this code when leaks are detected (default 0)")
+	flags.String("gitleaks-config", "", "Load a custom gitleaks config")
 
 	return scanCommand
 }
@@ -260,7 +293,7 @@ func runListen(cmd *cobra.Command, args []string) {
 				break
 			}
 
-			logger.Error("error reading from stdin: error=%q", err)
+			logger.Error("error reading from stdin: %v", err)
 
 			continue
 		}
@@ -269,7 +302,7 @@ func runListen(cmd *cobra.Command, args []string) {
 		err = json.Unmarshal(line, &request)
 
 		if err != nil {
-			logger.Error("could not unmarshal request: error=%q", err)
+			logger.Error("could not unmarshal request: %v", err)
 
 			continue
 		}
@@ -359,12 +392,14 @@ func rootCommand() *cobra.Command {
 	}
 
 	flags := rootCommand.PersistentFlags()
-	flags.StringP("config", "c", "", "config file path")
-	flags.StringP("format", "f", "", "output format [json, human, csv, toml, yaml] (default \"json\")")
+	flags.StringP("config", "c", "", "Load a custom leaktk config")
+	flags.StringP("format", "f", "", "Change the output format [json, human, csv, toml, yaml] (default \"json\")")
 
+	rootCommand.AddCommand(scanCommand())
+	rootCommand.AddCommand(installCommand())
 	rootCommand.AddCommand(loginCommand())
 	rootCommand.AddCommand(logoutCommand())
-	rootCommand.AddCommand(scanCommand())
+	rootCommand.AddCommand(hookCommand())
 	rootCommand.AddCommand(listenCommand())
 	rootCommand.AddCommand(versionCommand())
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -35,8 +35,8 @@ func TestScanCommandToRequest(t *testing.T) {
 	assert.Equal(t, "https://github.com/leaktk/fake-leaks.git", request.Resource)
 
 	// If resource starts with @ and the thing is a valid path, resource will be loaded from there
-	tmpDir := t.TempDir()
-	dataPath, err := fs.CleanJoin(tmpDir, "data.json")
+	tempDir := t.TempDir()
+	dataPath, err := fs.CleanJoin(tempDir, "data.json")
 	require.NoError(t, err)
 	err = os.WriteFile(dataPath, []byte("{\"some\": \"data\"}"), 0600)
 	require.NoError(t, err)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/leaktk/leaktk/pkg/logger"
+)
+
+func mustGetBool(flags *pflag.FlagSet, name string) bool {
+	value, err := flags.GetBool(name)
+	if err != nil {
+		logger.Fatal("unable to get flag: name=%q", name)
+	}
+	return value
+}
+
+func mustGetString(flags *pflag.FlagSet, name string) string {
+	value, err := flags.GetString(name)
+	if err != nil {
+		logger.Fatal("unable to get flag: name=%q", name)
+	}
+	return value
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/leaktk/leaktk/pkg/hooks"
+	"github.com/leaktk/leaktk/pkg/installer"
+	"github.com/leaktk/leaktk/pkg/logger"
+)
+
+func installCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install and configure leaktk subsystems",
+		Run:   runHelp,
+	}
+	cmd.AddCommand(hookInstallCommand())
+	return cmd
+}
+
+func hookInstallCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hook",
+		Short: "Install and configure hooks",
+		Run:   runHelp,
+	}
+	for _, hook := range hooks.Hooks {
+		switch hookkind := hook.Kind(); hookkind {
+		case hooks.GitHookKind:
+			cmd.AddCommand(gitHookInstallCommand(hook))
+		default:
+			logger.Fatal("hookkind not supported by installer: hookkind=%q", hookkind)
+		}
+	}
+	return cmd
+}
+
+func gitHookInstallCommand(hook hooks.Hook) *cobra.Command {
+	hookname := hook.Name()
+	cmd := &cobra.Command{
+		Use:   hookname,
+		Short: "Install and configure " + hookname,
+		Run:   runGitHookInstall,
+	}
+	flags := cmd.Flags()
+	flags.Bool("user-template-dir", false, fmt.Sprintf("Install the %s hook in your git init.templateDir (one is created if not already defined)", hookname))
+	flags.Bool("system-template-dir", false, fmt.Sprintf("Install the %s hook in /usr/share/git-core/templates", hookname))
+	flags.String("path", "", fmt.Sprintf("Install the %s hook in all git repositories under this path (unless --no-recursive is set)", hookname))
+	flags.Bool("no-recursive", false, fmt.Sprintf("Install the %s hook only at the repository at the selected path", hookname))
+	flags.Bool("force", false, fmt.Sprintf("Replace any existing %s hooks instead of skipping them", hookname))
+	return cmd
+}
+
+func runGitHookInstall(cmd *cobra.Command, args []string) {
+	flags := cmd.Flags()
+	opts := installer.GitHookOpts{
+		Hook:              hooks.Hook(cmd.Use),
+		UserTemplateDir:   mustGetBool(flags, "user-template-dir"),
+		SystemTemplateDir: mustGetBool(flags, "system-template-dir"),
+		Path:              mustGetString(flags, "path"),
+		Recursive:         !mustGetBool(flags, "no-recursive"),
+		Force:             mustGetBool(flags, "force"),
+	}
+
+	if len(opts.Path) == 0 && !opts.UserTemplateDir && !opts.SystemTemplateDir {
+		logger.Fatal("install requires at least one of: --path, --user-template-dir, --system-template-dir")
+	}
+
+	if err := installer.GitHookInstall(cmd.Context(), cfg, opts); err != nil {
+		logger.Fatal("could not install git hook: %v hookname=%q", err, opts.Hook.Name())
+	}
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -56,7 +56,7 @@ scan_workers = 1
 max_scan_queue_size = 1
 # How many items the response queue can hold in it before it blocks (0 default means non-blocking)
 max_response_queue_size = 1
-# The full path to where the scanner should store files, clone repos, etc
+# The full path to where the scanner should store files, cloned repositories, etc
 # for better performance mount a tmpfs at this location
 # workdir = "/tmp/leaktk/scanner" # This defaults to ${XDG_CACHE_HOME}/leaktk/scanner
 # Allow local scans on listen

--- a/docs/error_command_not_found.md
+++ b/docs/error_command_not_found.md
@@ -1,0 +1,52 @@
+# Error: leaktk command not found
+
+The `leaktk` binary could not be found in your `PATH`. This error appears when
+a hook or tool tries to execute leaktk but the `leaktk` command is not
+available in the shell environment.
+
+## Steps to resolve
+
+1. **Confirm leaktk is installed:**
+
+   ```sh
+   leaktk version
+   ```
+
+   If this fails, follow the [installation guide](install.md).
+
+2. **Ensure the directory it is installed in is in your PATH:**
+
+   This should return the path to the directory that the command is installed
+   under:
+
+   ```sh
+   echo "${PATH}" | grep -oF "$(dirname "$(command -v leaktk)")"
+   ```
+
+   If it doesn't, locate the directory that the leaktk command is installed in
+   and ensure it is included in your environment's path variable. If you are
+   unsure how, do a web search for "Set PATH variable on YOUR\_OS", replacing
+   YOUR\_OS with the name of your operating system (e.g. Linux, Mac, Windows).
+
+   After updating your PATH env variable, you may need to reload the environment
+   that you were running the Git commands in for the changes to apply. Or if
+   working from a terminal, you can source your terminal's config file:
+
+   ```sh
+   if [ -n "${BASH_VERSION}" ]; then source ~/.bashrc; else source ~/.zshrc; fi
+   ```
+
+## Removing Git Hooks
+
+If you want to stop using leaktk hooks entirely, remove the hook file:
+
+```sh
+rm .git/hooks/pre-commit
+```
+
+Or here is an example for removing it from all repositories under a provided path:
+
+```sh
+find . -name 'pre-commit' -type f -path '*/hooks/pre-commit' 2> /dev/null \
+  | xargs -I '{}' sh -c 'grep -E "\bleaktk\b" "{}" > /dev/null 2>&1 && rm -v "{}"'
+```

--- a/docs/false_positives.md
+++ b/docs/false_positives.md
@@ -1,0 +1,109 @@
+# False Positives
+
+A false positive is a finding that poses **no risk** to an individual or
+organization.
+
+See [Understanding Finding Types][1] for more information about what
+constitutes a false positive vs true positive or benign positive.
+
+## Ignoring False Positives
+
+> **🗒️ NOTE: If the finding is NOT a false positive, do not ignore it!**
+>
+> Follow the [remediation steps][2] to mitigate the risk.
+
+### Option 1: Make examples look less real
+
+> **🗒️ NOTE: This won't stop the scanner from alerting on previous commits without rewriting history**
+>
+> This is best used as a way to prevent initial false positives.
+
+> **⚠️  WARNING: If you do decide to rewrite history, be aware that it is a destructive action**
+
+If feasible, make example, placeholder, test, and dummy values look less real.
+This could include things like putting `EXAMPLE` in the value or `XXXX` or
+other similar values to ensure it doesn't look like a real secret.
+
+### Option 2: Add a supported ignore comment on the line containing the secret
+
+> **🗒️ NOTE: This won't stop the scanner from alerting on previous commits without rewriting history**
+>
+> This is best used as a way to prevent initial false positives.
+
+> **⚠️  WARNING: If you do decide to rewrite history, be aware that it is a destructive action**
+
+Similar to option 1, this communicates to the scanner and others that the example, placeholder, test, or dummy value is not a real secret.
+
+**Supported Comments:**
+
+- `notsecret` or `not secret` can be anywhere in the line, is case insensitive and the space is optional.
+- `gitleaks:allow` or `betterleaks:allow` given that the scanner is based on betterleaks, both of these tags are supported.
+
+There is also support to some extent for `nosec` and `noqa` comments but those are currently defined for certain rules and not broadly like the supported ones above.
+
+### Option 3: Add a `.gitleaks.toml`
+
+> **🗒️ NOTE: This option works best for ignoring historical false positives**
+
+> **⚠️  WARNING: Be careful not to add allowlists that are too broad**
+>
+> If the allowlist is too broad, it increases the risk of ignoring real secrets.
+
+LeakTK will look for a `.gitleaks.toml` file at the root of Git repositories
+and directories during a scan and merge any global allowlists it finds with its
+own. Allowlists are written in [TOML][3] and we currently support the [gitleaks
+v8 allowlist format][4].
+
+If multiple branches are scanned (the default if not providing a branch), the
+`.gitleaks.toml` on the [HEAD](https://git-scm.com/docs/gitglossary#def_HEAD)
+will be used. Otherwise the `.gitleaks.toml` on the provided branch will be
+used.
+
+LeakTK will **ignore**:
+
+- Files with any config errors
+- All `[[rules]]` tables and sub-tables
+- The `[extend]` table
+
+**Example Allowlists:**
+
+By default any field can match for an allowlist to apply, but if you want to
+require multiple fields to be true for an item to be allowed, you can set the
+`condition` field to AND like it is in one of the examples below.
+
+```toml
+# Ignore findings containing 'p4$$w0rd' (case insensitive) in the config and
+# response files in test.
+
+[[allowlists]] # Note the double braces and plural allowlists
+# AND here means that all of the "fields" defined much have match here
+condition = "AND"
+# stopwords are not regex and are just case insensitive string matches that
+# must be contained in the finding's secret
+stopwords = [
+    'p4$$w0rd',
+]
+paths = [
+    # Triple single quotes avoids needing to do TOML string escaping on top of
+    # any other regex escapes needed
+    '''^tests\/config\.json$''',
+    # "condition" is at the "field" level so any of these paths have to match
+    # with the stopword above for the rule to apply
+    '''^tests\/response\.json$''',
+]
+
+# Ignore anything that has the value '# nosec' at the end of the line
+[[allowlists]]
+# This sets the regex matcher to match against the "line" field rather than the
+# finding's "match" field or the "secret" field.
+regexTarget = 'line'
+regexes = [
+    # The '\s*' matches zero or more spaces
+    '''#\s*nosec\s*$''',
+]
+```
+
+[1]: findings.md#understanding-finding-types
+[2]: findings.md#remediation-steps
+[3]: https://toml.io/en/
+[4]: https://github.com/gitleaks/gitleaks/blob/67fcd836b3448e2d7bb928aa76082fc4ac894137/README.md#configuration

--- a/docs/findings.md
+++ b/docs/findings.md
@@ -1,0 +1,241 @@
+# Findings
+
+Findings are the secrets, credentials, and sensitive data that LeakTK's scanner
+detects in your code, repositories, or other scanned resources.
+
+This document covers:
+
+- How to interpret and respond to findings
+- Understanding different finding types (true positives, benign positives,
+  false positives)
+- Remediation steps for exposed secrets
+- Example finding formats from different scan modes
+
+See [Findings Examples](#findings-examples) below for sample output formats.
+
+
+## Responding to Findings
+
+When LeakTK reports a finding, you need to determine what type of finding it is
+before deciding how to respond. Understanding the distinction between different
+finding types is crucial for effective remediation.
+
+### Understanding Finding Types
+
+**What is a "Secret" in This Context?**
+
+A secret is any piece of sensitive information that, if exposed, could pose a
+risk to an individual or organization. This includes but is not limited to:
+
+- API keys and tokens
+- Database credentials
+- Private keys and certificates
+- OAuth tokens and session identifiers
+- Encryption keys
+- Personal Identifiable Information (PII)
+- Internal URLs or system configurations that reveal architecture
+
+**The sensitivity of a secret is highly contextual.** What's sensitive in one
+environment may not be in another, but err on the side of caution.
+
+**Finding Types:**
+
+1. **True Positive**: A real secret that should not be exposed.
+   - Production credentials
+   - Personal Identifiable Information (PII)
+   - Internal URLs or system configurations that reveal architecture
+   - Valid API keys with active permissions
+   - Real private keys
+   - **Important**: Pre-production credentials (dev, qa, staging, test) are still
+     secrets! They can provide attackers with valuable information about your
+     systems and may have more permissions than intended.
+
+2. **Benign Positive**: A real secret that's intentionally present and acceptable
+   - Revoked or expired credentials kept for historical reference
+   - Information stored somewhere where it's allowed to be stored (e.g.
+     Internal URLs in an internal Git repository)
+
+3. **False Positive**: Not actually a secret, just looks like one
+   - Dummy values in examples (e.g., `password: "your-password-here"`)
+   - Random strings that match secret patterns but aren't secrets
+   - Hash values or checksums that look like keys but aren't keys
+   - UUIDs or other identifiers that aren't actually sensitive
+   - Example secrets in documentation showing proper format
+   - Public API keys that are meant to be public (though these should be clearly
+     marked)
+
+**How to Determine the Finding Type:**
+
+1. **Examine the context**: Where did this appear? Is it in production code,
+   tests, documentation, or examples?
+
+2. **Verify if it's real**: Does this credential actually work? Can you use it
+   to access a system?
+
+3. **Assess the risk**: Even if it's "just" a dev credential, what could an
+   attacker do with it?
+
+4. **Check the intent**: Was this meant to be committed? Is it documented as
+   an example?
+
+**Next Steps Based on Finding Type:**
+
+- **True Positive**: Follow the remediation steps below immediately
+- **Benign Positive**: Consider if it should remain or be better documented;
+  you may want to add it to an ignore list (see [false positives](false_positives.md))
+- **False Positive**: Add appropriate ignore rules to prevent future noise
+  (see [false positives](false_positives.md))
+
+### Remediation Steps
+
+> **⚠️  WARNING: Destructive actions ahead!**
+>
+> Redacting sensitive information from any source is a **destructive action** that
+> permanently modifies or removes data. Whether you're rewriting Git history,
+> editing files, or cleaning up container images, these operations cannot be easily
+> undone.
+
+#### Step 1: Alert your Cyber Security Incident Response Team (CSIRT)
+
+> **🗒️ NOTE: This step applies to exposed company secrets.**
+
+> **⚠️  WARNING: Credentials to a personal account that has access to company
+> data are still in scope.**
+
+If the exposed secrets contain company credentials or data, it is important that
+you promptly notify your Cyber Security Incident Response Team (CSIRT).
+
+If you are unsure how, try searching your company's intranet for things like:
+
+- "Report Cybersecurity Concern"
+- "Report Security Incident"
+
+#### Step 1: Revoke all publicly exposed credentials
+
+> **🗒️ NOTE: This step only applies to publicly exposed credentials.**
+
+It is important that exposed credentials be rotated as soon as possible to
+minimize the risk of abuse. The specific steps for rotating credentials will
+vary depending on what the credentials.
+
+To find guides for rotating credentials:
+
+- Search "Rotate _Credential Type_"
+- Check out sites like [How to Rotate](https://howtorotate.com/)
+- Ask your CSIRT for help
+
+#### Step 3: Make a local backup
+
+This step will depend on the source of the leak.
+
+**For [remote Git repositories](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-remoterepository):**
+
+```sh
+git clone --mirror REMOTE_REPOSITORY_CLONE_URL "${HOME}/$(date +%s)-backup-containing-secrets-REPOSITORY_NAME.git"
+```
+
+Where:
+
+- `REMOTE_REPOSITORY_CLONE_URL` is the clone URL for the remote Git repository
+  that you plan to redact secrets from
+- `REPOSITORY_NAME` is the name you would like to have for the local backup
+
+**For a local Git repository:**
+
+```sh
+cp -r PATH_TO_REPOSITORY "${HOME}/$(date +%s)-backup-containing-secrets-REPOSITORY_NAME.git"
+```
+
+Where:
+
+- `PATH_TO_REPOSITORY` is the path to the local repository that you want to backup
+- `REPOSITORY_NAME` is the name you would like to have for the local backup
+
+**For other sources:**
+
+It will vary depending on the source, but the goal of the backup is to
+have as complete of a copy as you will need to restore the source if there
+are issues with the redaction process.
+
+#### Step 4: Redact the secrets
+
+> **⚠️  WARNING: This is a destructive action!**
+> Make sure you completed the previous backup step before continuing
+
+> **🗒️ NOTE: There may be cases where redaction is not necessary.**
+> In cases where redaction may cause more harm than good work with
+> your CSIRT to determine the right course of action.
+
+Like the backup process, the redaction process will depend on the source of the
+leak.
+
+**For Git repositories:**
+
+1. Install [git-filter-repo](https://github.com/newren/git-filter-repo/blob/main/INSTALL.md)
+2. Follow the [sensitive data removal guide](https://htmlpreview.github.io/?https://github.com/newren/git-filter-repo/blob/docs/html/git-filter-repo.html#_sensitive_data_removals)
+3. Some sources may have extra steps (e.g.
+   [GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) &
+   [GitLab](https://docs.gitlab.com/topics/git/repository/#purge-files-from-repository-history))
+
+**For other sources:**
+
+It will vary depending on the source, but the goal is to completely remove all
+references to the sensitive data from the source and ensure it is not
+inadvertently leaked again.
+
+If you have questions, please work with your CSIRT.
+
+## Findings Examples
+
+The findings might be formatted a little differently depending on how LeakTK is
+invoked to tailor it for that specific use case.
+
+For example when using LeakTK's Git commit hook, the findings might look
+similar to this:
+
+```
+Findings:
+
+- Description  : Generic Secret
+  Commit:      :
+  Path         : .env
+  Line Number  : 1
+  Encoding(s)  :
+
+- Description  : AWS Secret Access Key
+  Commit:      :
+  Path         : .env
+  Line Number  : 2
+  Encoding(s)  :
+```
+
+**Note:** The secret is not included in the output by the hooks to avoid
+spreading the secret further.
+
+Or if running the scanner directly on Git repository with the standard JSON
+output (expanded to make it easier to read):
+
+```
+{
+  ...
+  "results": [
+    {
+      "id": "DSFpsiJW0c4",
+      "kind": "GitCommit",
+      "secret": "SGcbDQvKIIskKSt4fbqp9b7LKknw+iYWF3nHSAf2B8M=",
+      "match": "secret=\"SGcbDQvKIIskKSt4fbqp9b7LKknw+iYWF3nHSAf2B8M=\"",
+      "context": "secret=\"SGcbDQvKIIskKSt4fbqp9b7LKknw+iYWF3nHSAf2B8M=\"",
+      "entropy": 4.9534163,
+      "date": "2026-04-22T19:14:02Z",
+      "rule": { "id": "_-9w6-yrc-4", "description": "Generic Secret", "tags": [ "type:secret", "alert:repo-owner" ] },
+      "contact": { "name": "Committer Name", "email": "commiter@example.com" },
+      "location": { "version": "a4375489f1ac5c0011035b34971d860cd6191b2f", "path": "secret", "start": {"line": 1, "column": 1 }, "end": { "line": 1, "column": 53 } },
+      "notes": {
+        "commit_message": "Add secret",
+        "gitleaks_fingerprint": "a4375489f1ac5c0011035b34971d860cd6191b2f:secret:_-9w6-yrc-4:1",
+        "repository": "."
+      }
+    }
+  ]
+}
+```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,27 @@
+# Hooks
+
+LeakTK-Hooks allows you to integrate secrets scanning into existing tools.
+
+## Git Hooks
+
+LeakTK supports the following [Git hooks](https://git-scm.com/docs/githooks):
+
+| Hook Name       | Audience                  | Purpose                                       |
+| --------------- | ------------------------- | --------------------------------------------- |
+| git.pre-commit  | Developers                | Block creating new commits containing secrets |
+| git.pre-receive | Git Server Administrators | Block Git pushes containing secrets           |
+
+See the Git hook specific [install guide](install_git_hooks.md) to get started.
+
+## Planned
+
+These are the hooks we want to implement next:
+
+- Claude Code Hooks
+- Cursor Hooks
+- Gemini CLI Hooks
+- Google Cloud Storage Hooks
+- AWS S3 Storage Hooks
+
+For more info or to request a hook type not covered here, leave a comment on:
+https://github.com/leaktk/leaktk/issues/238

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,11 @@
 # Installation
 
-There are several ways to install leaktk.
+The ways to install LeakTK are listed below. Also at the end of this guide are
+links to use case specific guides.
 
-## **🍺Homebrew (Mac)**
+## Installation Methods
+
+### **🍺Homebrew (Mac)**
 
 ```
 brew install leaktk/tap/leaktk
@@ -10,7 +13,7 @@ brew install leaktk/tap/leaktk
 
 (Note: We'll get this set up to work on Linux too)
 
-## **💻 Pre-built Binaries**
+### **💻 Pre-built Binaries**
 
 Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub
 Releases page for leaktk/leaktk](https://github.com/leaktk/leaktk/releases).
@@ -29,7 +32,7 @@ Releases page for leaktk/leaktk](https://github.com/leaktk/leaktk/releases).
 6. (Optional) Move the leaktk (or leaktk.exe on Windows) binary to a directory
    in your system's PATH (e.g., /usr/local/bin or C:\\Windows\\System32).
 
-## **📦 Using Docker/Podman (Container Image)**
+### **📦 Using Docker/Podman (Container Image)**
 
 Official container images are hosted on Quay.io.
 
@@ -69,13 +72,13 @@ podman run \
   --volume=./fake-leaks:/mnt:ro \
   quay.io/leaktk/leaktk:latest scan /mnt
 ```
-There are other ways to do it, but the above attemps to address:
+There are other ways to do it, but the above attempts to address:
 
 - UID & GID mapping: `--userns="keep-id:uid=1001,gid=0"`
 - SELinux context issues from accessing the host files from inside the container without relabeling them: `--security-opt=label=disable`
 - Making the host files accessible inside the container, but not letting the container modify them in any way: `--volume=./fake-leaks:/mnt:ro`
 
-## **🛠️ Build From Source on Linux & macOS**
+### **🛠️ Build From Source on Linux & macOS**
 
 If you have Go installed (version 1.23.3 or newer is recommended), you can install leaktk directly using go install:
 
@@ -94,3 +97,7 @@ CGO_ENABLED=0 GOBIN="${HOME}/.local/bin" go install github.com/leaktk/leaktk@vX.
 
 You will want to make sure you have `"${HOME}/.local/bin"` in your `PATH` if it
 isn't already.
+
+## Use-Case Specific Guides
+
+- [Git hook installation](install_git_hooks.md)

--- a/docs/install_git_hooks.md
+++ b/docs/install_git_hooks.md
@@ -1,0 +1,47 @@
+# Installing Git Hooks
+
+This guide walks you through the process of installing
+leaktk's supported [Git hooks](https://git-scm.com/docs/githooks).
+
+| Hook Name       | Audience                  | Purpose                                       |
+| --------------- | ------------------------- | --------------------------------------------- |
+| git.pre-commit  | Developers                | Block creating new commits containing secrets |
+| git.pre-receive | Git Server Administrators | Block Git pushes containing secrets           |
+
+## Prerequisites
+
+This guide requires that you have the `leaktk` command installed. If you do not already have
+it installed, see the main [installation guide](install.md).
+
+## Steps
+
+For this guide we're going to use the Git pre-commit hook, but the process is similar for the
+other hooks.
+
+1. Choose the hook you want to install (in our case it's `git.pre-commit`).
+1. Decide where you want to install it (this example will assume all Git
+   repositories under your home directory: `"${HOME}"`).
+1. Decide if you want to replace any existing hooks (this example will assume
+   yes so we'll add: `--force`)
+1. Decide if you want it to be enabled for new repositories by default (this
+   example assumes yes: `--user-template-dir`).
+1. Run the install command with the proper flags set:
+   ```sh
+   leaktk install hook git.pre-commit --force --user-template-dir --path "${HOME}"
+   ```
+You should see output similar to this:
+
+```
+...
+[INFO] installed hook: hook="git.pre-commit" path="/home/user/Workspace/leaktk-hack/.git/hooks/pre-commit"
+[INFO] installed hook: hook="git.pre-commit" path="/home/user/Workspace/leaktk-leaktk/.git/hooks/pre-commit"
+[INFO] installed hook: hook="git.pre-commit" path="/home/user/Workspace/leaktk-patterns/.git/hooks/pre-commit"
+[INFO] installed hook: hook="git.pre-commit" path="/home/user/.config/git/template/hooks/pre-commit"
+```
+
+If a directory that you expected it to be installed into is missing from the output, you can run the command in
+debug mode to see any directories that the command was unable to access or identify as a Git repository:
+
+```sh
+LEAKTK_LOGGER_LEVEL=DEBUG leaktk install hook git.pre-commit --force --user-template-dir --path "${HOME}"
+```

--- a/docs/listen.md
+++ b/docs/listen.md
@@ -54,20 +54,20 @@ Local:
 
 The `options` above are not required and some combined (e.g. `depth` and `since`)
 may cause issues. Refer to the details below to better understand the options
-and [git's docs](https://git-scm.com/) for knowing what can be combined.
+and [Git's docs](https://git-scm.com/) for knowing what can be combined.
 
 #### Request Options
 
 **branch**
 
-Sets `--branch` and `--single-branch` during git clone.
+Sets `--branch` and `--single-branch` during a `git clone`.
 
 * Type: `string`
 * Default: excluded
 
 **depth**
 
-Sets `--depth` during a git clone and can limit the commits during a local
+Sets `--depth` during a `git clone` and can limit the commits during a local
 scan if `single_branch` is set to true.
 
 * Type: `int`
@@ -76,9 +76,26 @@ scan if `single_branch` is set to true.
 Note: If both `since` and `depth` are set, `since` will be used for cloning but
 both are still used to filtering commits during the scan.
 
+**exclusions**
+
+A list of commits to exclude from the scan. These would be used by `git log` like:
+
+```sh
+# if the branch was "main" and "c3fb1349fa03741736f34d43b621de757571ee46" was in
+# the exclusions list, the `git log` command would be similar to:
+git log ^c3fb1349fa03741736f34d43b621de757571ee46 main
+```
+
+* Type: `[]string`
+* Default: excluded
+
+Example `"options":{"exclusions":["c3fb1349fa03741736f34d43b621de757571ee46"]}`
+
+See `<revision-range>` in `man 1 git-log` for more information.
+
 **local**
 
-Scans a local git repo instead of fetching a remote one. When listening
+Scans a local Git repository instead of fetching a remote one. When listening
 for jsonl requests this must be explicitly set. When running single scans
 it's inferred by the resource.
 
@@ -99,7 +116,7 @@ both are still used to filtering commits during the scan.
 **staged**
 
 Only scan staged changes. This takes priority over `unstaged` and is ignored
-for non-local repos.
+for non-local repositories.
 
 * Type: `bool`
 * Default: `false`
@@ -122,7 +139,7 @@ Sets the request priority. Higher priority items will be scanned first.
 **unstaged**
 
 Scan current changes rather than the history. `staged` takes priority over this
-and is ignored for non-local repos.
+and is ignored for non-local repositories.
 
 * Type: `bool`
 * Default: `false`

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -29,6 +29,6 @@ were errors during the scan.
 
 For most scans `leaktk scan [--kind=<kind>] <resource>` is enough, but more
 information about the supported kinds of resources and specific options for
-each resource can be found in the docs for [listen mode](./listen.md). The
+each resource can be found in the docs for [listen mode](listen.md). The
 options listed in that doc can be provided with the `--options` flag and
 should be formated as a JSON string.

--- a/docs/uninstall_git_hooks.md
+++ b/docs/uninstall_git_hooks.md
@@ -1,0 +1,47 @@
+# Uninstalling Git Hooks
+
+This guide walks you through the process of uninstalling
+LeakTK's supported [Git hooks](https://git-scm.com/docs/githooks).
+
+| Hook Name       | Audience                  | Purpose                                       |
+| --------------- | ------------------------- | --------------------------------------------- |
+| git.pre-commit  | Developers                | Block creating new commits containing secrets |
+| git.pre-receive | Git Server Administrators | Block Git pushes containing secrets           |
+
+## Prerequisites
+
+This guide assumes you are working in a Unix-like environment (e.g. Mac, Linux) with the
+`find`, `xargs`, and `rm` commands available on your system.
+
+## Steps
+
+For this guide we're going to use the Git pre-commit hook, but the process is similar for the
+other hooks.
+
+1. Choose the hook you want to uninstall (in our case it's `git.pre-commit`).
+1. Change directories in your terminal to the directory containing the Git repository or multiple repositories containing the hook.
+1. Run this command to remove the hook from all repositories under your current directory:
+   ```sh
+   find . -name 'pre-commit' -type f -path '*/hooks/pre-commit' 2> /dev/null \
+     | xargs -I '{}' sh -c 'grep -E "^#\s*CreatedBy:\s*leaktk" "{}" > /dev/null 2>&1 && rm -v "{}"'
+   ```
+1. If you installed the hook with the `--user-template-dir` flag, you can uninstall it from there using:
+   ```sh
+   git config --path init.templateDir \
+     | xargs -I '{}' sh -c 'grep -E "^#\s*CreatedBy:\s*leaktk" "{}/hooks/pre-commit" > /dev/null 2>&1 && rm -v "{}/hooks/pre-commit"'
+   ```
+
+You should see output similar to this when uninstalling it from the repositories:
+
+```
+...
+removed './leaktk-hack/.git/hooks/pre-commit'
+removed './leaktk-leaktk/.git/hooks/pre-commit'
+removed './leaktk-patterns/.git/hooks/pre-commit'
+```
+
+And something like this when uninstalling it from your Git template directory:
+
+```
+removed '/home/user/.config/git/template/hooks/pre-commit'
+```

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/rs/zerolog v1.35.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -113,7 +114,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.19.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/sylabs/sif/v2 v2.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
-golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=

--- a/hack/integrationtest
+++ b/hack/integrationtest
@@ -1,0 +1,145 @@
+#!/bin/sh
+set -eu
+
+echo '##############################################################################'
+
+echo 'Set up env'
+set -x
+export workdir="$(mktemp -d)"
+export LEAKTK_LOGGER_LEVEL='DEBUG'
+bindir="${workdir}/bin"
+repodir="${workdir}/repo"
+export PATH="${bindir}:${PATH}"
+set +x
+
+echo '##############################################################################'
+
+echo 'Defer cleanup'
+set -x
+trap 'rm -rf "${workdir}"' EXIT
+set +x
+
+echo '##############################################################################'
+
+echo 'Install package'
+set -x
+make clean build 
+make install PREFIX="${workdir}"
+set +x
+
+echo '##############################################################################'
+
+echo 'Setting up repo dir'
+set -x
+git init "${repodir}"
+git -C "${repodir}" branch -m main 
+set +x
+
+echo '##############################################################################'
+
+echo 'Setting up a remote for the repo'
+set -x
+remotedir="${workdir}/origin.git"
+git init --bare "${remotedir}"
+git -C "${repodir}" remote add origin "${remotedir}"
+set +x
+
+echo '##############################################################################'
+
+echo 'Installing hooks'
+set -x
+"${bindir}/leaktk" install hook git.pre-commit --path "${workdir}" --force
+"${bindir}/leaktk" install hook git.pre-receive --path "${workdir}" --force
+set +x
+
+echo '##############################################################################'
+
+echo 'Confirming TemplateID:'
+set -x
+if !  grep -F \
+	'f2998aee-4684-4c46-b724-7c8e37e6020c' \
+	"${repodir}/.git/hooks/pre-commit"
+then
+	echo "could not find template id"
+	exit 1
+fi
+set +x
+
+echo '##############################################################################'
+
+echo 'Trying to commit a secret'
+set -x
+echo 'secret="4bza9wI5Vb71N6Ahaa7IaqcPBrzzVREZSgmo1FnCHDg="' > "${repodir}/test.py"  # notsecret
+git -C "${repodir}" add test.py
+if ! git -C "${repodir}" commit \
+	--no-gpg-sign \
+	--message='This should fail' > /dev/null 2>&1
+then
+	echo '[PASS] Block a simple secret'
+fi
+set +x
+
+echo '##############################################################################'
+
+echo 'Marking the secret as #notsecret'
+set -x
+echo 'secret="4bza9wI5Vb71N6Ahaa7IaqcPBrzzVREZSgmo1FnCHDg=" # notsecret' >  "${repodir}/test.py"
+if ! git -C "${repodir}" commit \
+	--no-gpg-sign \
+	--message='This should fail' > /dev/null 2>&1
+then
+	echo '[PASS] adding #notsecret to unstaged does not make a difference'
+fi
+set +x
+
+echo '##############################################################################'
+
+echo 'Staging the changes with #notsecret set'
+set -x
+git -C "${repodir}" add test.py
+if git -C "${repodir}" commit \
+	--no-gpg-sign \
+	--message='This should pass' > /dev/null 2>&1
+then
+	echo '[PASS] Allow things marked as not secret'
+fi
+set +x
+
+echo '##############################################################################'
+
+echo 'Push whats there so far'
+set -x
+git -C "${repodir}" push -u origin
+set +x
+
+echo '##############################################################################'
+
+echo 'Commit secret'
+set -x
+echo 'secret="4bza9wI5Vb71N6Ahaa7IaqcPBrzzVREZSgmo1FnCHDg="' > "${repodir}/test.py"  # notsecret
+git -C "${repodir}" add test.py
+git -C "${repodir}" commit \
+	--no-gpg-sign \
+	--no-verify \
+	--message='Woot some secret' > /dev/null 2>&1
+
+if ! git -C "${repodir}" push > /dev/null 2>&1
+then
+	echo '[PASS] secrets should be blocked by pre-receive'
+fi
+set +x
+
+echo '##############################################################################'
+
+echo 'Add a secret and ignore it in the .gitleaks.toml'
+set -x
+openssl genrsa > "${repodir}/key.pem"
+echo -e "[[allowlists]]\npaths=['''^key\.pem\$''']" > "${repodir}/.gitleaks.toml"
+git -C "${repodir}" add key.pem .gitleaks.toml
+git -C "${repodir}" commit \
+	--no-gpg-sign \
+	--message='Should be ignored' > /dev/null 2>&1
+set +x
+
+echo '##############################################################################'
+echo "DONE"

--- a/hack/integrationtest
+++ b/hack/integrationtest
@@ -23,7 +23,7 @@ echo '##########################################################################
 
 echo 'Install package'
 set -x
-make clean build-pipe 
+make clean build
 make install PREFIX="${workdir}"
 set +x
 
@@ -108,8 +108,7 @@ set +x
 echo '##############################################################################'
 
 echo 'Push whats there so far'
-set -x
-git -C "${repodir}" push -u origin
+git -C "${repodir}" push -u origin main
 set +x
 
 echo '##############################################################################'

--- a/hack/integrationtest
+++ b/hack/integrationtest
@@ -14,6 +14,16 @@ set +x
 
 echo '##############################################################################'
 
+echo 'Configure test git'
+set -x
+export GIT_CONFIG_GLOBAL="${workdir}/gitconfig"
+export GIT_CONFIG_NOSYSTEM='1'
+git config --global user.email "test@${HOSTNAME:-'localhost'}"
+git config --global user.name "Test"
+set +x
+
+echo '##############################################################################'
+
 echo 'Defer cleanup'
 set -x
 trap 'rm -rf "${workdir}"' EXIT
@@ -32,7 +42,7 @@ echo '##########################################################################
 echo 'Setting up repo dir'
 set -x
 git init "${repodir}"
-git -C "${repodir}" branch -m main 
+git -C "${repodir}" branch -m main
 set +x
 
 echo '##############################################################################'
@@ -71,9 +81,7 @@ echo 'Trying to commit a secret'
 set -x
 echo 'secret="4bza9wI5Vb71N6Ahaa7IaqcPBrzzVREZSgmo1FnCHDg="' > "${repodir}/test.py"  # notsecret
 git -C "${repodir}" add test.py
-if ! git -C "${repodir}" commit \
-	--no-gpg-sign \
-	--message='This should fail' > /dev/null 2>&1
+if ! git -C "${repodir}" commit --message='This should fail' > /dev/null 2>&1
 then
 	echo '[PASS] Block a simple secret'
 fi
@@ -84,9 +92,7 @@ echo '##########################################################################
 echo 'Marking the secret as #notsecret'
 set -x
 echo 'secret="4bza9wI5Vb71N6Ahaa7IaqcPBrzzVREZSgmo1FnCHDg=" # notsecret' >  "${repodir}/test.py"
-if ! git -C "${repodir}" commit \
-	--no-gpg-sign \
-	--message='This should fail' > /dev/null 2>&1
+if ! git -C "${repodir}" commit --message='This should fail' > /dev/null 2>&1
 then
 	echo '[PASS] adding #notsecret to unstaged does not make a difference'
 fi
@@ -97,9 +103,7 @@ echo '##########################################################################
 echo 'Staging the changes with #notsecret set'
 set -x
 git -C "${repodir}" add test.py
-if git -C "${repodir}" commit \
-	--no-gpg-sign \
-	--message='This should pass' > /dev/null 2>&1
+if git -C "${repodir}" commit --message='This should pass' > /dev/null 2>&1
 then
 	echo '[PASS] Allow things marked as not secret'
 fi
@@ -108,6 +112,8 @@ set +x
 echo '##############################################################################'
 
 echo 'Push whats there so far'
+set -x
+git -C "${repodir}" branch -a
 git -C "${repodir}" push -u origin main
 set +x
 
@@ -117,10 +123,7 @@ echo 'Commit secret'
 set -x
 echo 'secret="4bza9wI5Vb71N6Ahaa7IaqcPBrzzVREZSgmo1FnCHDg="' > "${repodir}/test.py"  # notsecret
 git -C "${repodir}" add test.py
-git -C "${repodir}" commit \
-	--no-gpg-sign \
-	--no-verify \
-	--message='Woot some secret' > /dev/null 2>&1
+git -C "${repodir}" commit --no-verify --message='Woot some secret' > /dev/null 2>&1
 
 if ! git -C "${repodir}" push > /dev/null 2>&1
 then
@@ -135,9 +138,7 @@ set -x
 openssl genrsa > "${repodir}/key.pem"
 echo -e "[[allowlists]]\npaths=['''^key\.pem\$''']" > "${repodir}/.gitleaks.toml"
 git -C "${repodir}" add key.pem .gitleaks.toml
-git -C "${repodir}" commit \
-	--no-gpg-sign \
-	--message='Should be ignored' > /dev/null 2>&1
+git -C "${repodir}" commit --message='Should be ignored' > /dev/null 2>&1
 set +x
 
 echo '##############################################################################'

--- a/hack/integrationtest
+++ b/hack/integrationtest
@@ -23,7 +23,7 @@ echo '##########################################################################
 
 echo 'Install package'
 set -x
-make clean build 
+make clean build-pipe 
 make install PREFIX="${workdir}"
 set +x
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,140 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/leaktk/leaktk/pkg/config"
+	"github.com/leaktk/leaktk/pkg/logger"
+)
+
+// GitRepoInfo is a collection of facts about a repo being scanned.
+// See `man 7 gitglossary` for more information about the terms.
+type RepoInfo struct {
+	// Whether or not the repo is a bare repo
+	IsBare bool
+	// The path to the actual GIT_DIR folder
+	GitDir string
+	// The working tree for the repo (a temp one is created for bare repos)
+	WorkingTreePath string
+}
+
+func GetRepoInfo(ctx context.Context, path string) (RepoInfo, error) {
+	info := RepoInfo{WorkingTreePath: path}
+	cmd := CommandContext(
+		ctx,
+		"-C",
+		path,
+		"rev-parse",
+		// The order of these flags affects the field order below
+		"--absolute-git-dir",
+		"--is-bare-repository",
+	) // #nosec G204
+
+	logger.Debug("executing: %s", cmd)
+	rawInfo, err := cmd.Output()
+	if err != nil {
+		return info, err
+	}
+
+	fields := bytes.Split(bytes.TrimSpace(rawInfo), []byte("\n"))
+	if len(fields) != 2 {
+		return info, errors.New("could not load git repo info")
+	}
+
+	// Load the field data from above
+	info.GitDir = string(fields[0])
+	info.IsBare = bytes.Equal(fields[1], []byte("true"))
+
+	// Resolve the working tree to the toplevel path
+	if !info.IsBare {
+		// Running this separate since it's more prone to error out
+		cmd := CommandContext(
+			ctx,
+			"-C",
+			info.WorkingTreePath,
+			"rev-parse",
+			"--show-toplevel",
+		) // #nosec G204
+		logger.Debug("executing: %s", cmd)
+		rawTopLevel, err := cmd.Output()
+		if err == nil {
+			info.WorkingTreePath = string(bytes.TrimSpace(rawTopLevel))
+			logger.Debug("setting working tree to toplevel dir: path=%q", info.WorkingTreePath)
+		} else {
+			logger.Debug("unable to set working tree: %v", err)
+		}
+	}
+
+	return info, nil
+}
+
+func RunContext(ctx context.Context, args ...string) error {
+	cmd := CommandContext(ctx, args...)
+	logger.Debug("executing: %s", cmd)
+	return cmd.Run()
+}
+
+// RemoteRefExists checks if the provided ref exists on the remote repo
+func RemoteRefExists(ctx context.Context, repository, ref string) bool {
+	return RunContext(ctx, "ls-remote", "--exit-code", "--quiet", repository, ref) == nil
+}
+
+// GetGlobalConfigPath gets a value from the global config and applies a --type=path flag
+// to handle normalizing it
+func GetGlobalConfigPath(ctx context.Context, name string) string {
+	// Handle undoing the override for this operation
+	if os.Getenv("GIT_CONFIG_GLOBAL") == config.GitConfigGlobalOverride {
+		if err := os.Unsetenv("GIT_CONFIG_GLOBAL"); err != nil {
+			logger.Fatal("Unable to properly configure git env: %v", err)
+		}
+	}
+
+	logger.Debug("getting global config value: name=%q", name)
+	cmd := CommandContext(ctx, "config", "--global", "--type=path", name)
+
+	logger.Debug("executing: %s", cmd)
+	output, err := cmd.Output()
+	if err != nil {
+		// if the value isn't set properly or at all, treat it like it's not set at all
+		logger.Debug("existing value not found: %v name=%q", err, name)
+		if err := os.Setenv("GIT_CONFIG_GLOBAL", config.GitConfigGlobalOverride); err != nil {
+			logger.Fatal("Unable to properly configure git env: %v", err)
+		}
+
+		return ""
+	}
+
+	if err := os.Setenv("GIT_CONFIG_GLOBAL", config.GitConfigGlobalOverride); err != nil {
+		logger.Fatal("Unable to properly configure git env: %v", err)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// SetGlobalConfigPath sets a value in the global config and applies a --type=path flag
+// to handle normalizing it
+func SetGlobalConfigPath(ctx context.Context, name, value string) error {
+	// Handle undoing the override for this operation
+	if os.Getenv("GIT_CONFIG_GLOBAL") == config.GitConfigGlobalOverride {
+		if err := os.Unsetenv("GIT_CONFIG_GLOBAL"); err != nil {
+			logger.Fatal("Unable to properly configure git env: %v", err)
+		}
+	}
+
+	logger.Debug("setting global config value: name=%q value=%q", name, value)
+	if err := RunContext(ctx, "config", "--global", "--type=path", name, value); err != nil {
+		if err := os.Setenv("GIT_CONFIG_GLOBAL", config.GitConfigGlobalOverride); err != nil {
+			logger.Fatal("Unable to properly configure git env: %v", err)
+		}
+		return fmt.Errorf("could not set git config value: %w name=%q value=%q", err, name, value)
+	}
+
+	if err := os.Setenv("GIT_CONFIG_GLOBAL", config.GitConfigGlobalOverride); err != nil {
+		logger.Fatal("Unable to properly configure git env: %v", err)
+	}
+	return nil
+}

--- a/internal/git/git_command_unix.go
+++ b/internal/git/git_command_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package scanner
+package git
 
 import (
 	"context"
@@ -8,10 +8,10 @@ import (
 	"syscall"
 )
 
-// gitCommand sets extra things on the command like the pgid
+// CommandContext sets extra things on the command like the pgid
 // and cancel function to ensure the command doesn't hang
 // when in weird states
-func gitCommand(ctx context.Context, args ...string) *exec.Cmd {
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {

--- a/internal/git/git_command_windows.go
+++ b/internal/git/git_command_windows.go
@@ -1,14 +1,14 @@
 //go:build windows
 
-package scanner
+package git
 
 import (
 	"context"
 	"os/exec"
 )
 
-// gitCommand for windows exists for compatibility with
+// CommandContext for windows exists for compatibility with
 // the unix version that does some extra pgroup managment
-func gitCommand(ctx context.Context, args ...string) *exec.Cmd {
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, "git", args...)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,9 @@ import (
 	"github.com/leaktk/leaktk/pkg/version"
 )
 
+// GitConfigGlobalOverride helps normalize things in the scanner
+// it is a variable here so other code can check if it's been set
+const GitConfigGlobalOverride = "/dev/null"
 const nixGlobalConfigDir = "/etc/leaktk"
 
 var localConfigDir string
@@ -23,16 +26,31 @@ func init() {
 
 	// The environment variables for the scan environment
 	env := map[string]string{
-		"GIT_CONFIG_GLOBAL":      "/dev/null",
+		"GIT_CONFIG_GLOBAL":      GitConfigGlobalOverride,
 		"GIT_TERMINAL_PROMPT":    "0",
 		"GIT_NO_REPLACE_OBJECTS": "1",
 		"GIT_CONFIG_NOSYSTEM":    "1",
 		"GIT_HTTP_USER_AGENT":    version.GlobalUserAgent,
 	}
 
-	for key, value := range env {
-		if err := os.Setenv(key, value); err != nil {
-			logger.Error("could not set %s=%s: %v", key, value, err)
+	for varname, value := range env {
+		if err := os.Setenv(varname, value); err != nil {
+			logger.Fatal("could not set %s=%s: %v", varname, value, err)
+		}
+	}
+
+	unsetEnv := []string{
+		// GIT_INDEX_FILE sets the path to the index file for non-bare
+		// repositories.  It is being unset here because the commands
+		// here are responsible for finding the index file themselves
+		// if needed and can cause unexpected behavior for the sub
+		// commands when used as hooks.
+		"GIT_INDEX_FILE",
+	}
+
+	for _, varname := range unsetEnv {
+		if err := os.Unsetenv(varname); err != nil {
+			logger.Fatal("could not unset %s: %v", varname, err)
 		}
 	}
 }

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -1,0 +1,44 @@
+package docs
+
+import (
+	"os"
+	"strings"
+)
+
+// BaseDocsURL is the URL that will be used to find docs by topic.
+// This can be overridden if providing custom docs.
+var BaseDocsURL = "https://github.com/leaktk/leaktk/blob/HEAD/docs/"
+
+// DocsExt is the extension added on to the doc topic by DocURL.
+// This can be overridden if providing custom docs.
+var DocsExt = ".md"
+
+// Topic is a topic that can be referenced in the docs.
+// This is used to generate the URL for the topic.
+type Topic string
+
+// A list of topics to referenc
+const (
+	CommandNotFoundTopic = Topic("error_command_not_found")
+	FalsePositivesTopic  = Topic("false_positives")
+	FindingsTopic        = Topic("findings")
+)
+
+func init() {
+	// Look up LEAKTK_DOCS_BASE_URL environment variable
+	if base := strings.TrimSpace(os.Getenv("LEAKTK_DOCS_BASE_URL")); base != "" {
+		BaseDocsURL = base
+	}
+	// Look up LEAKTK_DOCS_EXT environment variable
+	if ext := strings.TrimSpace(os.Getenv("LEAKTK_DOCS_EXT")); ext != "" {
+		DocsExt = ext
+	}
+	// Make sure the base URL ends with a slash
+	if BaseDocsURL[len(BaseDocsURL)-1] != '/' {
+		BaseDocsURL += "/"
+	}
+}
+
+func DocURL(topic Topic) string {
+	return BaseDocsURL + string(topic) + DocsExt
+}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -40,6 +40,15 @@ func PathExists(path string) bool {
 	return info != nil && err == nil
 }
 
+// IsExecutable checks if a file exists and is executable
+func IsExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&0111 != 0
+}
+
 // CleanJoin checks to make sure that the prefix path remains after the join, this is to
 // control for path traversal
 func CleanJoin(prefix string, elem string) (string, error) {

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestFileExists(t *testing.T) {
-	tmpDir := t.TempDir()
-	tmpFile := filepath.Join(tmpDir, "file")
+	tempDir := t.TempDir()
+	tmpFile := filepath.Join(tempDir, "file")
 
 	t.Run("DirIsNotAFile", func(t *testing.T) {
-		assert.False(t, FileExists(tmpDir))
+		assert.False(t, FileExists(tempDir))
 	})
 
 	t.Run("FileExists", func(t *testing.T) {
@@ -30,11 +30,11 @@ func TestFileExists(t *testing.T) {
 }
 
 func TestPathExists(t *testing.T) {
-	tmpDir := t.TempDir()
-	tmpFile := filepath.Join(tmpDir, "file")
+	tempDir := t.TempDir()
+	tmpFile := filepath.Join(tempDir, "file")
 
 	t.Run("DirExists", func(t *testing.T) {
-		assert.True(t, PathExists(tmpDir))
+		assert.True(t, PathExists(tempDir))
 	})
 
 	t.Run("FileExists", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestPathExists(t *testing.T) {
 	})
 
 	t.Run("DirDoesntExist", func(t *testing.T) {
-		noDir := filepath.Join(tmpDir, "foo/bar/baz")
+		noDir := filepath.Join(tempDir, "foo/bar/baz")
 		assert.False(t, PathExists(noDir))
 	})
 
@@ -56,16 +56,16 @@ func TestPathExists(t *testing.T) {
 
 func TestCleanJoin(t *testing.T) {
 	t.Run("CleanJoin", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		err := os.MkdirAll(filepath.Join(tmpDir, "foo"), 0700)
+		tempDir := t.TempDir()
+		err := os.MkdirAll(filepath.Join(tempDir, "foo"), 0700)
 		require.NoError(t, err)
 
 		testPathFail := "../../hello/world"
-		_, err = CleanJoin(tmpDir, testPathFail)
+		_, err = CleanJoin(tempDir, testPathFail)
 		require.Error(t, err)
 
 		testPathPass := "hello/world..zip"
-		_, err = CleanJoin(tmpDir, testPathPass)
+		_, err = CleanJoin(tempDir, testPathPass)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/fs/fs_unix.go
+++ b/pkg/fs/fs_unix.go
@@ -1,0 +1,39 @@
+//go:build darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd
+
+package fs
+
+import (
+	"io/fs"
+	"os"
+	"strconv"
+	"syscall"
+)
+
+const FileLockSupported = true
+
+func flock(f *os.File, lt int16) (err error) {
+	for {
+		err = syscall.Flock(int(f.Fd()), int(lt)) // #nosec G115
+		if err != syscall.EINTR {
+			break
+		}
+	}
+	if err != nil {
+		return &fs.PathError{
+			Op:   strconv.Itoa(int(lt)),
+			Path: f.Name(),
+			Err:  err,
+		}
+	}
+	return nil
+}
+
+// LockFile locks a file using the flock syscall. Unlock doesn't need to be called if the file is closed.
+func LockFile(f *os.File) (err error) {
+	return flock(f, syscall.LOCK_EX)
+}
+
+// UnlockFile unlocks a file locked by LockFile. This doesn't need to be called if the file is closed
+func UnlockFile(f *os.File) error {
+	return flock(f, syscall.LOCK_UN)
+}

--- a/pkg/fs/fs_windows.go
+++ b/pkg/fs/fs_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package fs
+
+import (
+	"errors"
+	"os"
+)
+
+// FileLockSupport is set to false on windows because at the moment the file lock use case is mainly
+// for servers running things like the git.pre-recieve hook. This may change latter.
+const FileLockSupported = false
+
+// LockFile is not implemented for this platform
+func LockFile(f *os.File) (err error) {
+	return errors.New("file locking currently not supported for windows")
+}
+
+// Unlockfile is not implemented for this platform
+func UnlockFile(f *os.File) error {
+	return errors.New("file locking currently not supported for windows")
+}

--- a/pkg/hooks/git_common.go
+++ b/pkg/hooks/git_common.go
@@ -1,0 +1,78 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/leaktk/leaktk/pkg/docs"
+	"github.com/leaktk/leaktk/pkg/proto"
+)
+
+const gitHookResultsWarningHeader = `
+Findings:
+`
+
+const gitHookResultWarningTemplate = `
+- Description  : %s
+  Commit:      : %s
+  Path         : %s
+  Line Number  : %d
+  Encoding(s)  : %s
+`
+
+const gitHookResultsWarningFooter = `
+==============================================================================
+COMMIT BLOCKED: POTENTIAL SECRETS DETECTED
+------------------------------------------------------------------------------
+Please remove any sensitive information listed above and try again.
+
+For excluding non-sensitive findings:
+%s
+
+For more information on interpreting these results:
+%s
+==============================================================================
+`
+
+func gitHookResultEncodings(result *proto.Result) string {
+	var encodings strings.Builder
+
+	encodingPrefix := "decoded:"
+	encodingPrefixLen := len(encodingPrefix)
+	tags := result.Rule.Tags
+
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, encodingPrefix) {
+			if encodings.Len() > 0 {
+				encodings.WriteString(", ")
+			}
+
+			encodings.WriteString(tag[encodingPrefixLen:])
+		}
+	}
+
+	return encodings.String()
+}
+
+func gitHookDisplayResults(results []*proto.Result) {
+	fmt.Fprint(os.Stderr, gitHookResultsWarningHeader)
+	for _, result := range results {
+		fmt.Fprintf(
+			os.Stderr,
+			gitHookResultWarningTemplate,
+			result.Rule.Description,
+			result.Location.Version,
+			result.Location.Path,
+			result.Location.Start.Line,
+			gitHookResultEncodings(result),
+		)
+	}
+
+	fmt.Fprintf(
+		os.Stderr,
+		gitHookResultsWarningFooter,
+		docs.DocURL(docs.FalsePositivesTopic),
+		docs.DocURL(docs.FindingsTopic),
+	)
+}

--- a/pkg/hooks/git_pre_commit.go
+++ b/pkg/hooks/git_pre_commit.go
@@ -1,0 +1,55 @@
+package hooks
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/leaktk/leaktk/pkg/config"
+	"github.com/leaktk/leaktk/pkg/id"
+	"github.com/leaktk/leaktk/pkg/logger"
+	"github.com/leaktk/leaktk/pkg/proto"
+	"github.com/leaktk/leaktk/pkg/scanner"
+)
+
+func gitPreCommitRun(cfg *config.Config, hook Hook, _ []string) (int, error) {
+	var resultsMutex sync.Mutex
+	var results []*proto.Result
+	var wg sync.WaitGroup
+
+	leaktkScanner := scanner.NewScanner(cfg)
+
+	// Prints the output of the scanner as they come
+	go leaktkScanner.Recv(func(response *proto.Response) {
+		if response.Error != nil {
+			logger.Fatal("scan response contains error: %v", response.Error)
+		}
+
+		if len(response.Results) > 0 {
+			resultsMutex.Lock()
+			results = append(results, response.Results...)
+			resultsMutex.Unlock()
+		}
+		wg.Done()
+	})
+
+	wg.Add(1)
+	leaktkScanner.Send(&proto.Request{
+		ID:       fmt.Sprintf("leaktk.%s.%s", hook.Name(), id.ID()),
+		Kind:     proto.GitRepoRequestKind,
+		Resource: ".",
+		Opts: proto.Opts{
+			Local:  true,
+			Staged: true,
+		},
+	})
+
+	wg.Wait()
+	if len(results) > 0 {
+		gitHookDisplayResults(results)
+		return 1, nil
+	} else {
+		logger.Info("no secrets detected")
+	}
+
+	return 0, nil
+}

--- a/pkg/hooks/git_pre_commit_test.go
+++ b/pkg/hooks/git_pre_commit_test.go
@@ -1,0 +1,79 @@
+package hooks
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leaktk/leaktk/pkg/config"
+)
+
+const betterleaksPreCommitTestConfig = `
+[[rules]]
+id = "test-pre-commit"
+regex = '''secret\s*=\s*"secretvalue"'''
+`
+
+func TestGitPreCommit(t *testing.T) {
+	tempDir := filepath.Clean(t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.Scanner.Patterns.Autofetch = false
+	cfg.Scanner.Patterns.ExpiredAfter = 0
+	cfg.Scanner.Patterns.RefreshAfter = 0
+	cfg.Scanner.Patterns.Gitleaks.ConfigPath = filepath.Join(tempDir, ".git/gitleaks.toml")
+
+	ctx := t.Context()
+
+	// Chdir into the tempDir since the hook is executed from the git dir
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	defer func() { assert.NoError(t, os.Chdir(origWd)) }()
+
+	// Create a git repo
+	require.NoError(t, exec.CommandContext(ctx, "git", "-C", tempDir, "init").Run()) // #nosec G204
+
+	// Setup the betterleaks config
+	file, err := os.Create(cfg.Scanner.Patterns.Gitleaks.ConfigPath)
+	require.NoError(t, err)
+	_, err = file.Write([]byte(betterleaksPreCommitTestConfig))
+	_ = file.Close()
+	require.NoError(t, err)
+
+	// Write a non-secret to the repo
+	nonSecretFilePath := filepath.Join(tempDir, "some-file")
+	file, err = os.Create(nonSecretFilePath)
+	require.NoError(t, err)
+	_, err = file.Write([]byte("Hello, world!"))
+	_ = file.Close()
+	require.NoError(t, err)
+
+	// Stage the changes
+	require.NoError(t, exec.CommandContext(ctx, "git", "add", nonSecretFilePath).Run()) // #nosec G204
+
+	// Run a scan (should not have findings)
+	statusCode, err := gitPreCommitRun(cfg, "git.pre-commit", []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, statusCode)
+
+	// Write a secret to the repo
+	secretFilePath := filepath.Join(tempDir, "secret-file")
+	file, err = os.Create(secretFilePath)
+	require.NoError(t, err)
+	_, err = file.Write([]byte("secret=\"secretvalue\""))
+	_ = file.Close()
+	require.NoError(t, err)
+
+	// Stage the changes
+	require.NoError(t, exec.CommandContext(ctx, "git", "add", secretFilePath).Run()) // #nosec G204
+
+	// Run a scan (should have findings)
+	statusCode, err = gitPreCommitRun(cfg, "git.pre-commit", []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, statusCode)
+}

--- a/pkg/hooks/git_pre_receive.go
+++ b/pkg/hooks/git_pre_receive.go
@@ -1,0 +1,109 @@
+package hooks
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/leaktk/leaktk/pkg/config"
+	"github.com/leaktk/leaktk/pkg/id"
+	"github.com/leaktk/leaktk/pkg/logger"
+	"github.com/leaktk/leaktk/pkg/proto"
+	"github.com/leaktk/leaktk/pkg/scanner"
+)
+
+// pre-receive line format:
+// <old-oid> SP <new-oid> SP <ref-name> LF
+// OIDs are 40 characters and 255 seems to be a limit for ref names
+// So 4096 should be plenty and align it with a page of memory
+const gitPreReceiveMaxLineLimit = 4096
+
+var emptyOID = []byte("0000000000000000000000000000000000000000")
+
+func gitPreReceiveRun(cfg *config.Config, hook Hook, _ []string) (int, error) {
+	var resultsMutex sync.Mutex
+	var results []*proto.Result
+	var wg sync.WaitGroup
+
+	leaktkScanner := scanner.NewScanner(cfg)
+
+	// Prints the output of the scanner as they come
+	go leaktkScanner.Recv(func(response *proto.Response) {
+		if response.Error != nil {
+			logger.Fatal("scan response contains error: %v", response.Error)
+		}
+
+		if len(response.Results) > 0 {
+			resultsMutex.Lock()
+			results = append(results, response.Results...)
+			resultsMutex.Unlock()
+		}
+		wg.Done()
+	})
+
+	refsReader := bufio.NewReaderSize(os.Stdin, 4096)
+	for {
+		line, isPrefix, err := refsReader.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			logger.Fatal("error reading from stdin: %v", err)
+		}
+
+		if isPrefix {
+			logger.Fatal("line too large: len(<old-oid> SP <new-oid> SP <ref-name> LF) must be < %d", gitPreReceiveMaxLineLimit)
+		}
+
+		oldIDStart := 0
+		oldIDEnd := bytes.IndexByte(line, ' ')
+		if oldIDEnd != 40 {
+			logger.Debug("unexpected oldIDEnd: expected=40 actual=%d", oldIDEnd)
+			logger.Fatal("expected line to start with '[0-9a-z]{40} ': line=%q", line)
+		}
+
+		newIDStart := oldIDEnd + 1
+		newIDEnd := newIDStart + bytes.IndexByte(line[newIDStart:], ' ')
+		if newIDEnd != 81 {
+			logger.Debug("unexpected newIDEnd: expected=81 actual=%d", newIDEnd)
+			logger.Fatal("expected line to start with '[0-9a-z]{40} [0-9a-z]{40}': line=%q", line)
+		}
+
+		newID := line[newIDStart:newIDEnd]
+		if bytes.Equal(newID, emptyOID) {
+			logger.Debug("skipping delete-ref line: line=%q", line)
+			continue
+		}
+
+		// Create exclusions list from the oldID if it points to a non-empty object ID
+		var exclusions []string
+		if oldID := line[oldIDStart:oldIDEnd]; !bytes.Equal(oldID, emptyOID) {
+			exclusions = []string{string(oldID)}
+		}
+
+		wg.Add(1)
+		leaktkScanner.Send(&proto.Request{
+			ID:       fmt.Sprintf("leaktk.%s.%s", hook.Name(), id.ID()),
+			Kind:     proto.GitRepoRequestKind,
+			Resource: ".",
+			Opts: proto.Opts{
+				Local:      true,
+				Branch:     string(newID),
+				Exclusions: exclusions,
+			},
+		})
+	}
+
+	wg.Wait()
+	if len(results) > 0 {
+		gitHookDisplayResults(results)
+		return 1, nil
+	} else {
+		logger.Info("no secrets detected")
+	}
+
+	return 0, nil
+}

--- a/pkg/hooks/git_pre_receive_test.go
+++ b/pkg/hooks/git_pre_receive_test.go
@@ -1,0 +1,121 @@
+package hooks
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leaktk/leaktk/pkg/config"
+)
+
+const betterleaksPreReceiveTestConfig = `
+[[rules]]
+id = "test-pre-receive"
+regex = '''secret\s*=\s*"secretvalue"'''
+`
+
+// TestGitPreReceive only tests the function itself but does not do a full integration test
+func TestGitPreReceive(t *testing.T) {
+	tempDir := filepath.Clean(t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.Scanner.Patterns.Autofetch = false
+	cfg.Scanner.Patterns.ExpiredAfter = 0
+	cfg.Scanner.Patterns.RefreshAfter = 0
+	cfg.Scanner.Patterns.Gitleaks.ConfigPath = filepath.Join(tempDir, ".git/gitleaks.toml")
+
+	ctx := t.Context()
+
+	// Chdir into the tempDir since the hook is executed from the git dir
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	defer func() { assert.NoError(t, os.Chdir(origWd)) }()
+
+	// Mock Stdin
+	mockStdin, err := os.OpenFile(filepath.Join(tempDir, "stdin"), os.O_RDWR|os.O_CREATE, 0600)
+	defer func() { require.NoError(t, mockStdin.Close()) }()
+	require.NoError(t, err)
+	origStdin := os.Stdin
+	defer func() { os.Stdin = origStdin }()
+	os.Stdin = mockStdin
+
+	// Create a git repo
+	require.NoError(t, exec.CommandContext(ctx, "git", "-C", tempDir, "init").Run())                                       // #nosec G204
+	require.NoError(t, exec.CommandContext(ctx, "git", "-C", tempDir, "config", "user.email", "leaktk@example.com").Run()) // #nosec G204
+	require.NoError(t, exec.CommandContext(ctx, "git", "-C", tempDir, "config", "user.name", "LeakTK").Run())              // #nosec G204
+
+	// Setup the betterleaks config
+	file, err := os.Create(cfg.Scanner.Patterns.Gitleaks.ConfigPath)
+	require.NoError(t, err)
+	_, err = file.Write([]byte(betterleaksPreReceiveTestConfig))
+	_ = file.Close()
+	require.NoError(t, err)
+
+	// Write a non-secret to the repo
+	nonSecretFilePath := filepath.Join(tempDir, "some-file")
+	file, err = os.Create(nonSecretFilePath)
+	require.NoError(t, err)
+	_, err = file.Write([]byte("Hello, world!"))
+	_ = file.Close()
+	require.NoError(t, err)
+
+	// Stage the changes
+	require.NoError(t, exec.CommandContext(ctx, "git", "-C", tempDir, "add", nonSecretFilePath).Run())                             // #nosec G204
+	require.NoError(t, exec.CommandContext(ctx, "git", "-C", tempDir, "commit", "-m", "add non-secret file", "--no-verify").Run()) // #nosec G204
+	nonSecretCommitID, err := exec.CommandContext(ctx, "git", "-C", tempDir, "rev-parse", "HEAD").Output()                         // #nosec G204
+	require.NoError(t, err)
+	nonSecretCommitID = bytes.TrimSpace(nonSecretCommitID)
+
+	// Setup the data for pre-receive to handle
+	_, err = mockStdin.Seek(0, 0)
+	require.NoError(t, err)
+	_, _ = mockStdin.Write(emptyOID)
+	_, _ = mockStdin.WriteString(" ")
+	_, _ = mockStdin.Write(nonSecretCommitID)
+	_, _ = mockStdin.WriteString(" ")
+	_, _ = mockStdin.WriteString("refs/heads/main\n")
+	_, err = mockStdin.Seek(0, 0)
+	require.NoError(t, err)
+
+	// Run a scan (should not have findings)
+	statusCode, err := gitPreReceiveRun(cfg, "git.pre-receive", []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, statusCode)
+
+	// Write a secret to the repo
+	secretFilePath := filepath.Join(tempDir, "secret-file")
+	file, err = os.Create(secretFilePath)
+	require.NoError(t, err)
+	_, err = file.Write([]byte("secret=\"secretvalue\""))
+	_ = file.Close()
+	require.NoError(t, err)
+
+	// Stage the changes
+	require.NoError(t, exec.CommandContext(ctx, "git", "-C", tempDir, "add", secretFilePath).Run())                            // #nosec G204
+	require.NoError(t, exec.CommandContext(ctx, "git", "-C", tempDir, "commit", "-m", "add secret file", "--no-verify").Run()) // #nosec G204
+	secretCommitID, err := exec.CommandContext(ctx, "git", "-C", tempDir, "rev-parse", "HEAD").Output()                        // #nosec G204
+	require.NoError(t, err)
+	secretCommitID = bytes.TrimSpace(secretCommitID)
+
+	// Setup the data for pre-receive to handle
+	_, err = mockStdin.Seek(0, 0)
+	require.NoError(t, err)
+	_, _ = mockStdin.Write(nonSecretCommitID)
+	_, _ = mockStdin.WriteString(" ")
+	_, _ = mockStdin.Write(secretCommitID)
+	_, _ = mockStdin.WriteString(" ")
+	_, _ = mockStdin.WriteString("refs/heads/main\n")
+	_, err = mockStdin.Seek(0, 0)
+	require.NoError(t, err)
+
+	// Run a scan (should have findings)
+	statusCode, err = gitPreReceiveRun(cfg, "git.pre-receive", []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, statusCode)
+}

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -1,0 +1,75 @@
+package hooks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/leaktk/leaktk/pkg/config"
+	"github.com/leaktk/leaktk/pkg/logger"
+)
+
+// Hook is a wrapper around a hookname to abstract parsing it
+// consistently. All hooknames must follow this format:
+// ```ebnf
+// hookname = hookkind "." hookevent
+//
+// # All hook kinds must be accounted for in the cmd/install.go file
+// hookkind = "git"
+//
+// # hookevent values depend on the events supported by
+// # the hookkind
+// hookevent = /a-z(?:[a-z0-9\-]+)?[a-z0-9]?/
+// ```
+type HookKind string
+type Hook string
+
+const (
+	GitHookKind = HookKind("git")
+)
+
+const (
+	GitPreCommitHook  = Hook(GitHookKind + ".pre-commit")
+	GitPreReceiveHook = Hook(GitHookKind + ".pre-receive")
+)
+
+// Hooks defines all the hooks suported
+var Hooks = []Hook{
+	GitPreCommitHook,
+	GitPreReceiveHook,
+}
+
+// Name returns the full name of the hook
+func (h Hook) Name() string {
+	return string(h)
+}
+
+// Kind returns the kind of hook (e.g. git, claude, gcs, etc..)
+func (h Hook) Kind() HookKind {
+	kind, _, found := strings.Cut(h.Name(), ".")
+	if !found {
+		logger.Fatal("invalid hookname format: hookname=%q", h.Name())
+	}
+	return HookKind(kind)
+}
+
+// Event returns name of the event/phase of a process that this hook alters
+// (e.g. pre-commit, pre-receive, user-prompt-submit, etc...)
+func (h Hook) Event() string {
+	_, event, found := strings.Cut(h.Name(), ".")
+	if !found {
+		logger.Fatal("invalid hookname format: hookname=%q", h.Name())
+	}
+	return event
+}
+
+// Run executes the provided hook with its arguments
+func Run(cfg *config.Config, hook Hook, args []string) (int, error) {
+	switch hook {
+	case GitPreReceiveHook:
+		return gitPreReceiveRun(cfg, hook, args)
+	case GitPreCommitHook:
+		return gitPreCommitRun(cfg, hook, args)
+	default:
+		return 1, fmt.Errorf("invalid hookname: hookname=%q", hook.Name())
+	}
+}

--- a/pkg/installer/git_hook.go
+++ b/pkg/installer/git_hook.go
@@ -1,0 +1,222 @@
+package installer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	iofs "io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/adrg/xdg"
+
+	"github.com/leaktk/leaktk/internal/git"
+	"github.com/leaktk/leaktk/pkg/config"
+	"github.com/leaktk/leaktk/pkg/docs"
+	"github.com/leaktk/leaktk/pkg/fs"
+	"github.com/leaktk/leaktk/pkg/hooks"
+	"github.com/leaktk/leaktk/pkg/logger"
+	"github.com/leaktk/leaktk/pkg/version"
+)
+
+const systemGitTemplateDir = "/usr/share/git-core/templates"
+
+// GitHookOpts contains flags and options to pass to the git hook installer
+type GitHookOpts struct {
+	// Hook is the hook to install (e.g. hooks.Hook("git.pre-commit"))
+	Hook hooks.Hook
+	// Path is the directory to search for git repositories to install into
+	Path string
+	// Recursive tells the installer to look git repositories in sub-paths.
+	Recursive bool
+	// Force replaces existing hooks instead of skipping them
+	Force bool
+	// SystemTemplateDir installs the hook in /usr/share/git-core/templates
+	SystemTemplateDir bool
+	// UserTemplateDir installs the hook in the user's git init.templateDir
+	// (one is created at ~/.config/git/template if not already configured)
+	UserTemplateDir bool
+}
+
+// gitPreCommitHookTemplate is the shell script written to .git/hooks/pre-commit.
+// TemplateID SHOULD stay the same across leaktk versions as long as this
+// script's content does not change, so repos can be audited by template version.
+const gitPreCommitHookTemplate = `#!/bin/sh
+# TemplateID: f2998aee-4684-4c46-b724-7c8e37e6020c
+# CreatedBy: %s
+# CreatedOn: %s
+if command -v leaktk > /dev/null 2>&1
+then
+    exec leaktk hook %s
+else
+    echo 'leaktk command not found' >&2
+    echo 'See: %s' >&2
+    exit 1
+fi
+`
+
+// findGitDirs returns the absolute git directory path for every git repository
+// found at or under the root path
+func findGitDirs(ctx context.Context, root string) ([]string, error) {
+	// Use a set in case multiple worktrees point to the same git dir
+	gitDirSet := make(map[string]bool)
+
+	err := filepath.WalkDir(root, func(path string, d iofs.DirEntry, err error) error {
+		if err != nil {
+			logger.Debug("could not access path: %v path=%q", err, path)
+			return nil
+		}
+
+		// Ignore anything that isn't a .git file or directory
+		if !strings.HasSuffix(d.Name(), ".git") {
+			logger.Trace("skipping path without .git suffix: path=%q", path)
+			return nil
+		}
+
+		repoInfo, err := git.GetRepoInfo(ctx, path)
+		if err != nil {
+			logger.Debug("could not get repo info: %v path=%q", err, path)
+			return nil
+		}
+
+		// Add the new dir to the gitDirSet
+		if !gitDirSet[repoInfo.GitDir] {
+			gitDirSet[repoInfo.GitDir] = true
+		}
+		return nil
+	})
+
+	return slices.Sorted(maps.Keys(gitDirSet)), err
+}
+
+// gitUserTemplateDir returns the path to the user's git init.templateDir.
+// If init.templateDir is not configured, it creates a default directory at
+// $XDG_CONFIG_HOME/git/template and sets init.templateDir to that path.
+func gitUserTemplateDir(ctx context.Context) (string, error) {
+	// NOTE: GetGlobalConfigPath handles ~ expansion for paths in git configs
+	templateDir := git.GetGlobalConfigPath(ctx, "init.templateDir")
+	if len(templateDir) > 1 {
+		return templateDir, nil
+	}
+
+	templateDir = filepath.Join(xdg.ConfigHome, "git", "template")
+	if err := os.MkdirAll(templateDir, 0750); err != nil {
+		return "", fmt.Errorf("could not create user git template dir: %w path=%q", err, templateDir)
+	}
+
+	if err := git.SetGlobalConfigPath(ctx, "init.templateDir", templateDir); err != nil {
+		return "", fmt.Errorf("could not set user git template dir: %w path=%q", err, templateDir)
+	}
+
+	logger.Info("configured user git template dir: path=%q", templateDir)
+	return templateDir, nil
+}
+
+// gitHookInstall installs a git hook script into installDir (the .git directory).
+func gitHookInstall(hook hooks.Hook, installDir string, force bool, perm os.FileMode) error {
+	hooksDir := filepath.Join(installDir, "hooks")
+	hookPath := filepath.Join(hooksDir, hook.Event())
+
+	if gitHookExists(hookPath) && !force {
+		logger.Info("skipping existing hook: force install not enabled: path=%q force_install=%v", hookPath, force)
+		return nil
+	}
+
+	if err := os.MkdirAll(hooksDir, perm); err != nil {
+		return fmt.Errorf("could not create hooks dir: %w path=%q", err, hooksDir)
+	}
+
+	createdBy := "leaktk-" + version.Version
+	createdOn := time.Now().UTC().Format(time.RFC3339)
+	script := fmt.Sprintf(
+		gitPreCommitHookTemplate,
+		createdBy,
+		createdOn,
+		hook.Name(),
+		docs.DocURL(docs.CommandNotFoundTopic),
+	)
+
+	if err := os.WriteFile(hookPath, []byte(script), perm); err != nil { // #nosec G306 -- hook script must be executable
+		return fmt.Errorf("could not write hook: %w path=%q", err, hookPath)
+	}
+	logger.Info("installed hook: hook=%q path=%q", hook.Name(), hookPath)
+	return nil
+}
+
+// GitHookInstall installs git hooks according to opts.
+// It installs in all git repos found under opts.Path, and optionally in the
+// user's git init.templateDir and/or the system git template directory.
+func GitHookInstall(ctx context.Context, cfg *config.Config, opts GitHookOpts) error {
+	var err error
+	var gitDirs []string
+
+	hookname := opts.Hook.Name()
+	hadErrors := false
+
+	if opts.Path != "" {
+		if !fs.PathExists(opts.Path) {
+			return fmt.Errorf("path does not exist: path=%q", opts.Path)
+		}
+
+		if !opts.Recursive {
+			repoInfo, err := git.GetRepoInfo(ctx, opts.Path)
+			if err != nil {
+				return fmt.Errorf("could not find git repo: %w hookname=%q path=%q", err, hookname, opts.Path)
+			}
+			if len(repoInfo.GitDir) > 0 {
+				gitDirs = append(gitDirs, repoInfo.GitDir)
+			}
+		} else {
+			gitDirs, err = findGitDirs(ctx, opts.Path)
+			if err != nil {
+				return fmt.Errorf("could not find git repos: %w hookname=%q path=%q", err, hookname, opts.Path)
+			}
+		}
+
+		if len(gitDirs) == 0 {
+			logger.Warning("no git repositories found: hookname=%q path=%q", hookname, opts.Path)
+		}
+
+		for _, gitDir := range gitDirs {
+			if err := gitHookInstall(opts.Hook, gitDir, opts.Force, 0750); err != nil {
+				logger.Info("could not install hook: %v hookname=%q path=%q", err, hookname, gitDir)
+				hadErrors = true
+			}
+		}
+	}
+
+	if opts.UserTemplateDir {
+		userGitTemplateDir, err := gitUserTemplateDir(ctx)
+		if err != nil {
+			logger.Error("could not resolve user template dir: %v hookname=%s", err, hookname)
+			hadErrors = true
+		} else {
+			if err := gitHookInstall(opts.Hook, userGitTemplateDir, opts.Force, 0750); err != nil {
+				logger.Info(
+					"could not install hook in user git template dir: %v hookname=%q path=%q",
+					err, hookname, userGitTemplateDir,
+				)
+				hadErrors = true
+			}
+		}
+	}
+
+	if opts.SystemTemplateDir {
+		if err := gitHookInstall(opts.Hook, systemGitTemplateDir, opts.Force, 0755); err != nil {
+			logger.Info(
+				"could not install hook in system git template dir: %v hookname=%q path=%q",
+				err, hookname, systemGitTemplateDir,
+			)
+			hadErrors = true
+		}
+	}
+
+	if hadErrors {
+		return errors.New("errors detected during install")
+	}
+	return nil
+}

--- a/pkg/installer/git_hook_test.go
+++ b/pkg/installer/git_hook_test.go
@@ -1,0 +1,199 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leaktk/leaktk/internal/git"
+	"github.com/leaktk/leaktk/pkg/config"
+	"github.com/leaktk/leaktk/pkg/fs"
+	"github.com/leaktk/leaktk/pkg/hooks"
+)
+
+// setupGitRepo creates a git repository in the given directory
+// It disables git template directory to avoid using the host's templates
+func setupGitRepo(t *testing.T, repoPath string, bare bool) {
+	ctx := t.Context()
+
+	if bare {
+		require.NoError(t, git.RunContext(ctx, "-c", "init.templateDir=", "init", "--bare", repoPath))
+	} else {
+		require.NoError(t, git.RunContext(ctx, "-c", "init.templateDir=", "init", repoPath))
+	}
+}
+
+func cleanPath(t *testing.T, path string) string {
+	var err error
+	path, err = filepath.Abs(path)
+	require.NoError(t, err)
+	path, err = filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	return path
+}
+
+func TestGitInstallHook(t *testing.T) {
+	t.Run("gitCreateHookScript", func(t *testing.T) {
+		tempDir := t.TempDir()
+		setupGitRepo(t, tempDir, false)
+
+		// Test installing a hook
+		hook := hooks.GitPreCommitHook
+		require.NoError(t, gitHookInstall(hook, tempDir, false, 0750))
+
+		// Verify the hook was created
+		hookPath := filepath.Join(tempDir, "hooks", "pre-commit")
+		assert.True(t, fs.FileExists(hookPath))
+
+		// Verify the hook exists
+		assert.True(t, gitHookExists(hookPath))
+
+		// Read and verify hook content
+		content, err := os.ReadFile(hookPath) // #nosec G304 -- test code reading test file
+		require.NoError(t, err)
+
+		contentStr := string(content)
+		// Frontmatter must have a space after the #
+		assert.True(t, strings.HasPrefix(contentStr, "#!/bin/sh\n# TemplateID:"), "script must start with shebang and spaced frontmatter")
+		// Must contain the command-v guard
+		assert.Contains(t, contentStr, "if command -v leaktk > /dev/null 2>&1")
+		assert.Contains(t, contentStr, "exec leaktk hook git.pre-commit")
+		// Must contain the error doc link
+		assert.Contains(t, contentStr, "docs/error_command_not_found")
+		// Must NOT exec unconditionally (the old broken form)
+		assert.NotContains(t, contentStr, "\nexec leaktk")
+	})
+
+	t.Run("findGitDirs", func(t *testing.T) {
+		tempDir := t.TempDir()
+		ctx := t.Context()
+
+		// Regular repo
+		repo1Dir := filepath.Join(tempDir, "repo1")
+		setupGitRepo(t, repo1Dir, false)
+
+		// Bare repo
+		repo2Dir := filepath.Join(tempDir, "repo2.git")
+		setupGitRepo(t, repo2Dir, true)
+
+		// Nested repo (under a subdirectory)
+		repo3Dir := filepath.Join(tempDir, "nested", "repo3")
+		setupGitRepo(t, repo3Dir, false)
+
+		t.Run("finds all recursively", func(t *testing.T) {
+			gitDirs, err := findGitDirs(ctx, tempDir)
+			require.NoError(t, err)
+			assert.Len(t, gitDirs, 3)
+		})
+
+		t.Run("finds single repo when pointed at it directly", func(t *testing.T) {
+			gitDirs, err := findGitDirs(ctx, repo1Dir)
+			require.NoError(t, err)
+			assert.Len(t, gitDirs, 1)
+			assert.Equal(t, cleanPath(t, filepath.Join(repo1Dir, ".git")), cleanPath(t, gitDirs[0]))
+		})
+
+		t.Run("finds bare repo", func(t *testing.T) {
+			gitDirs, err := findGitDirs(ctx, repo2Dir)
+			require.NoError(t, err)
+			assert.Len(t, gitDirs, 1)
+			assert.Equal(t, cleanPath(t, repo2Dir), cleanPath(t, gitDirs[0]))
+		})
+
+		t.Run("non-git directory returns empty", func(t *testing.T) {
+			emptyDir := filepath.Join(tempDir, "notarepo")
+			require.NoError(t, os.MkdirAll(emptyDir, 0700))
+			gitDirs, err := findGitDirs(ctx, emptyDir)
+			require.NoError(t, err)
+			assert.Empty(t, gitDirs)
+		})
+	})
+
+	t.Run("install in single repo", func(t *testing.T) {
+		tempDir := t.TempDir()
+		setupGitRepo(t, tempDir, false)
+
+		cfg := &config.Config{}
+		err := GitHookInstall(t.Context(), cfg, GitHookOpts{
+			Hook:  hooks.GitPreCommitHook,
+			Path:  tempDir,
+			Force: false,
+		})
+		require.NoError(t, err)
+		hookPath := filepath.Join(tempDir, ".git", "hooks", "pre-commit")
+		assert.True(t, gitHookExists(hookPath))
+	})
+
+	t.Run("installs in all repos under path when recursive is set", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo1Dir := filepath.Join(tempDir, "repo1")
+		repo2Dir := filepath.Join(tempDir, "repo2")
+
+		setupGitRepo(t, repo1Dir, false)
+		setupGitRepo(t, repo2Dir, false)
+
+		cfg := &config.Config{}
+		err := GitHookInstall(t.Context(), cfg, GitHookOpts{
+			Hook:      hooks.GitPreCommitHook,
+			Force:     true,
+			Path:      tempDir,
+			Recursive: true,
+		})
+		require.NoError(t, err)
+		hook1 := filepath.Join(repo1Dir, ".git", "hooks", "pre-commit")
+		hook2 := filepath.Join(repo2Dir, ".git", "hooks", "pre-commit")
+		assert.True(t, gitHookExists(hook1))
+		assert.True(t, gitHookExists(hook2))
+	})
+
+	t.Run("skips existing hook when force=false", func(t *testing.T) {
+		tempDir := t.TempDir()
+		setupGitRepo(t, tempDir, false)
+
+		cfg := &config.Config{}
+		opts := GitHookOpts{Hook: hooks.GitPreCommitHook, Path: tempDir, Force: false}
+
+		// First install should add the hook
+		require.NoError(t, GitHookInstall(t.Context(), cfg, opts))
+		info, err := os.Stat(filepath.Join(tempDir, ".git", "hooks", "pre-commit"))
+		require.NoError(t, err)
+		originalMtime := info.ModTime()
+
+		// Second install should not update the hook because force is not enabled
+		require.NoError(t, GitHookInstall(t.Context(), cfg, opts))
+		info2, err := os.Stat(filepath.Join(tempDir, ".git", "hooks", "pre-commit"))
+		require.NoError(t, err)
+		assert.Equal(t, originalMtime, info2.ModTime(), "file should not have been overwritten")
+	})
+
+	t.Run("overwrites existing hook when force=true", func(t *testing.T) {
+		tempDir := t.TempDir()
+		setupGitRepo(t, tempDir, false)
+
+		cfg := &config.Config{}
+		opts := GitHookOpts{Hook: hooks.GitPreCommitHook, Path: tempDir, Force: true}
+		require.NoError(t, GitHookInstall(t.Context(), cfg, opts))
+		info, err := os.Stat(filepath.Join(tempDir, ".git", "hooks", "pre-commit"))
+		require.NoError(t, err)
+		originalMtime := info.ModTime()
+		time.Sleep(10 * time.Millisecond)
+		require.NoError(t, GitHookInstall(t.Context(), cfg, opts))
+		info2, err := os.Stat(filepath.Join(tempDir, ".git", "hooks", "pre-commit"))
+		require.NoError(t, err)
+		assert.NotEqual(t, originalMtime, info2.ModTime(), "file should have been overwritten")
+	})
+
+	t.Run("returns error for nonexistent path", func(t *testing.T) {
+		cfg := &config.Config{}
+		err := GitHookInstall(t.Context(), cfg, GitHookOpts{
+			Hook: hooks.GitPreCommitHook,
+			Path: filepath.Join(t.TempDir(), "nonexistent"),
+		})
+		require.Error(t, err)
+	})
+}

--- a/pkg/installer/git_hook_unix.go
+++ b/pkg/installer/git_hook_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package installer
+
+import (
+	"github.com/leaktk/leaktk/pkg/fs"
+)
+
+// gitHookExists reports whether an existing git hook exists at a given path for determining if
+// one should be replaced or skipped
+func gitHookExists(path string) bool {
+	return fs.IsExecutable(path)
+}

--- a/pkg/installer/git_hook_windows.go
+++ b/pkg/installer/git_hook_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package installer
+
+import (
+	"github.com/leaktk/leaktk/pkg/fs"
+)
+
+// gitHookExists reports whether an existing git hook exists at a given path for determining if
+// one should be replaced or skipped
+func gitHookExists(path string) bool {
+	// On windows fs.IsExecutable doesn't work as expected
+	return fs.FileExists(path)
+}

--- a/pkg/scanner/betterleaks/scan.go
+++ b/pkg/scanner/betterleaks/scan.go
@@ -20,12 +20,12 @@ var defaultRemote = &sources.RemoteInfo{}
 
 // GitScanOpts configures ScanGit
 type GitScanOpts struct {
-	Branch   string
-	Depth    int
-	Remote   *sources.RemoteInfo
-	Since    string
-	Staged   bool
-	Unstaged bool
+	RevisionRange string
+	Depth         int
+	Remote        *sources.RemoteInfo
+	Since         string
+	Staged        bool
+	Unstaged      bool
 }
 
 // ContainerImageScanOpts configures ScanContainerImage
@@ -181,8 +181,8 @@ func newGitCmd(ctx context.Context, gitDir string, opts GitScanOpts) (gitCmd *so
 		logOpts = append(logOpts, strconv.Itoa(opts.Depth))
 	}
 
-	if len(opts.Branch) > 0 {
-		logOpts = append(logOpts, opts.Branch)
+	if len(opts.RevisionRange) > 0 {
+		logOpts = append(logOpts, opts.RevisionRange)
 	} else {
 		logOpts = append(logOpts, "--all")
 	}

--- a/pkg/scanner/patterns.go
+++ b/pkg/scanner/patterns.go
@@ -15,6 +15,7 @@ import (
 	betterleaksconfig "github.com/betterleaks/betterleaks/config"
 
 	"github.com/leaktk/leaktk/pkg/config"
+	"github.com/leaktk/leaktk/pkg/fs"
 	"github.com/leaktk/leaktk/pkg/logger"
 	"github.com/leaktk/leaktk/pkg/scanner/betterleaks"
 )
@@ -124,9 +125,41 @@ func (p *Patterns) Gitleaks(ctx context.Context) (*betterleaksconfig.Config, err
 			return p.gitleaksConfig, fmt.Errorf("could not create config dir: error=%q", err)
 		}
 
+		// Open the config file, creating it if it doesn't already exist, but don't truncate yet
+		configFile, err := os.OpenFile(p.config.Gitleaks.ConfigPath, os.O_RDWR|os.O_CREATE, 0600)
+		if err != nil {
+			return p.gitleaksConfig, fmt.Errorf("could not open config file: %v path=%q", err, p.config.Gitleaks.ConfigPath)
+		}
+
+		// defer the close and add logging around it since we're adding locks
+		defer func() {
+			if err := configFile.Close(); err != nil {
+				logger.Error("could not close config file: %v path=%q", err, p.config.Gitleaks.ConfigPath)
+				if err := fs.UnlockFile(configFile); err != nil {
+					logger.Error("error releasing config file lock: %v path=%q", err, p.config.Gitleaks.ConfigPath)
+				}
+			}
+		}()
+
+		// Establish a file lock to avoid different instances of the scanner writing to the config
+		if fs.FileLockSupported {
+			logger.Debug("locking config file for writes: path=%q", p.config.Gitleaks.ConfigPath)
+			if err = fs.LockFile(configFile); err != nil {
+				return p.gitleaksConfig, fmt.Errorf("could not establish a file lock: %w path=%s", err, p.config.Gitleaks.ConfigPath)
+			}
+		}
+
+		// Now that a lock's established if it's supported, seek to the beginning to be safe, truncate and write the file
+		if _, err := configFile.Seek(0, 0); err != nil {
+			return p.gitleaksConfig, fmt.Errorf("could not seek to the beginning of the config file: %w path=%s", err, p.config.Gitleaks.ConfigPath)
+		}
+		if err := configFile.Truncate(0); err != nil {
+			return p.gitleaksConfig, fmt.Errorf("could not truncate existing config file: %w path=%s", err, p.config.Gitleaks.ConfigPath)
+		}
+
 		// only write the config after parsing it, that way we don't break a good
 		// existing config if the server returns an invalid response
-		if err := os.WriteFile(p.config.Gitleaks.ConfigPath, []byte(rawConfig), 0600); err != nil {
+		if _, err := configFile.WriteString(rawConfig); err != nil {
 			return p.gitleaksConfig, fmt.Errorf("could not write config: path=%q error=%q", p.config.Gitleaks.ConfigPath, err)
 		}
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -12,6 +11,8 @@ import (
 
 	"github.com/betterleaks/betterleaks/detect"
 	"github.com/betterleaks/betterleaks/report"
+
+	"github.com/leaktk/leaktk/internal/git"
 
 	"github.com/leaktk/leaktk/pkg/config"
 	"github.com/leaktk/leaktk/pkg/fs"
@@ -134,13 +135,40 @@ func (s *Scanner) listen() {
 		var findings []report.Finding
 		switch request.Kind {
 		case proto.GitRepoRequestKind:
-			sourcePath := request.Resource
-			gitDir := request.Resource
+			var gitRepoInfo git.RepoInfo
 
-			if !request.Opts.Local {
-				if sourcePath, gitDir, err = s.cloneGitRepo(ctx, request.Resource, request.Opts); err != nil {
+			if request.Opts.Local {
+				// Make sure local scans are allowed before continuing
+				if !s.allowLocal {
+					logger.Critical("scan failed: local scans are not allowed: id=%q", request.ID)
+					s.respondWithError(request, &proto.Error{
+						Code:    localScanNotAllowedCode,
+						Message: "local scans not allowed",
+						Data:    request,
+					})
+
+					return
+				}
+
+				// Load the gitRepoInfo from the repo
+				gitRepoInfo, err = git.GetRepoInfo(ctx, request.Resource)
+				if err != nil {
+					logger.Critical("scan failed: could not get git repo info: %v id=%q", err, request.ID)
+					removeTempGitFiles(request, gitRepoInfo)
+					s.respondWithError(request, &proto.Error{
+						Code:    sourceErrorCode,
+						Message: "could not get git repo info",
+						Data:    request,
+					})
+					return
+				}
+			} else {
+				// Clone the repo and get its gitRepoInfo
+				gitRepoInfo, err = s.cloneGitRepo(ctx, request.Resource, request.Opts)
+				if err != nil {
 					select {
 					case <-ctx.Done():
+						removeTempGitFiles(request, gitRepoInfo)
 						s.respondWithError(request, &proto.Error{
 							Code:    cloneErrorCode,
 							Message: "clone operation timed out",
@@ -148,61 +176,53 @@ func (s *Scanner) listen() {
 						})
 					default:
 						logger.Critical("scan failed: could not clone git repo: %v id=%q", err, request.ID)
+						removeTempGitFiles(request, gitRepoInfo)
 						s.respondWithError(request, &proto.Error{
 							Code:    cloneErrorCode,
 							Message: "could not clone git repo",
 							Data:    request,
 						})
 					}
-
 					return
 				}
-			} else if !s.allowLocal {
-				logger.Critical("scan failed: local scans not allowed: id=%q", request.ID)
-				s.respondWithError(request, &proto.Error{
-					Code:    localScanNotAllowedCode,
-					Message: "local scans not allowed",
-					Data:    request,
-				})
-
-				return
 			}
 
-			gitDir, err = absGitDir(ctx, gitDir)
-			if err != nil {
-				logger.Critical("scan failed: could not determine gitdir: %v id=%q", err, request.ID)
-				s.respondWithError(request, &proto.Error{
-					Code:    sourceErrorCode,
-					Message: "could not determine gitdir",
-					Data:    request,
-				})
-
-				return
+			// Handle setting up a temp worktree for accessing certain files in bare repos
+			if gitRepoInfo.IsBare {
+				gitRepoInfo.WorkingTreePath, err = tempCheckoutGitSourceConfigFiles(ctx, gitRepoInfo.GitDir, request.Opts.Branch)
+				if err != nil {
+					// Only log this as a debug item since it shouldn't result in fewer findings but
+					// may result in more false positives
+					logger.Debug("could not set up temp working tree for bare repo: %v id=%q", err, request.ID)
+				}
 			}
 
-			if !request.Opts.Local {
-				defer (func() {
-					if fs.PathExists(sourcePath) {
-						if err := os.RemoveAll(sourcePath); err != nil {
-							logger.Error("could not remove source path: %v path=%q id=%q", err, sourcePath, request.ID)
-						}
-					}
-					if fs.PathExists(gitDir) {
-						if err := os.RemoveAll(gitDir); err != nil {
-							logger.Error("could not remove gitdir: %v path=%q id=%q", err, gitDir, request.ID)
-						}
-					}
-				})()
+			// Load the checked out config from the working tree
+			loadSourceConfig(detector, gitRepoInfo.WorkingTreePath)
+
+			// If there are exclusions, create a revision range like:
+			// ^{exclusion1} ^{exclusion2} {branch}
+			revisionRange := request.Opts.Branch
+			exclusionsLen := len(request.Opts.Exclusions)
+			if exclusionsLen > 0 {
+				items := make([]string, len(request.Opts.Exclusions)+1)
+				for i, item := range request.Opts.Exclusions {
+					items[i] = "^" + item
+				}
+				items[exclusionsLen] = request.Opts.Branch
+				revisionRange = strings.Join(items, " ")
 			}
 
-			loadSourceConfig(detector, sourcePath)
-			findings, err = betterleaks.ScanGit(ctx, detector, gitDir, betterleaks.GitScanOpts{
-				Branch:   request.Opts.Branch,
-				Depth:    scanDepth(request.Opts.Depth, s.maxScanDepth),
-				Since:    request.Opts.Since,
-				Staged:   request.Opts.Staged,
-				Unstaged: request.Opts.Unstaged,
+			findings, err = betterleaks.ScanGit(ctx, detector, gitRepoInfo.GitDir, betterleaks.GitScanOpts{
+				RevisionRange: revisionRange,
+				Depth:         scanDepth(request.Opts.Depth, s.maxScanDepth),
+				Since:         request.Opts.Since,
+				Staged:        request.Opts.Staged,
+				Unstaged:      request.Opts.Unstaged,
 			})
+
+			// Remove temp files as soon as they're no longer needed
+			removeTempGitFiles(request, gitRepoInfo)
 		case proto.URLRequestKind:
 			findings, err = betterleaks.ScanURL(ctx, detector, request.Resource, betterleaks.URLScanOpts{
 				FetchURLPatterns: splitFetchURLPatterns(request.Opts.FetchURLs),
@@ -290,6 +310,25 @@ func (s *Scanner) respondWithError(request *proto.Request, err *proto.Error) {
 	})
 }
 
+// removeTempGitFiles clears out any temp files or directories that were created for the scan
+// and should be safe to remove after the scan is finished
+func removeTempGitFiles(request *proto.Request, gitRepoInfo git.RepoInfo) {
+	// Remove temp repo clone if it was a remote scan
+	if !request.Opts.Local && fs.PathExists(gitRepoInfo.GitDir) {
+		logger.Debug("removing temp git dir: path=%q", gitRepoInfo.GitDir)
+		if err := os.RemoveAll(gitRepoInfo.GitDir); err != nil {
+			logger.Error("could not remove temp git dir: %v path=%q id=%q", err, gitRepoInfo.GitDir, request.ID)
+		}
+	}
+
+	// Remove temp git working tree created for accessing certain files from bare repos
+	if gitRepoInfo.IsBare && fs.PathExists(gitRepoInfo.WorkingTreePath) {
+		if err := os.RemoveAll(gitRepoInfo.WorkingTreePath); err != nil {
+			logger.Error("error removing temp working tree: %v path=%q id=%q", err, gitRepoInfo.WorkingTreePath, request.ID)
+		}
+	}
+}
+
 func findingToResult(request *proto.Request, finding *report.Finding) *proto.Result {
 	result := &proto.Result{
 		ID: id.ID(
@@ -358,7 +397,6 @@ func findingToResult(request *proto.Request, finding *report.Finding) *proto.Res
 		} else {
 			result.Notes["image"] = request.Resource
 		}
-
 	case proto.URLRequestKind:
 		result.Notes["url"] = request.Resource
 		result.Kind = proto.GenericResultKind
@@ -369,16 +407,9 @@ func findingToResult(request *proto.Request, finding *report.Finding) *proto.Res
 	return result
 }
 
-func absGitDir(ctx context.Context, path string) (string, error) {
-	cmd := gitCommand(ctx, "-C", path, "rev-parse", "--absolute-git-dir") // #nosec G204
-	logger.Debug("executing: %s", cmd)
-	stdout, err := cmd.Output()
-
-	return string(bytes.TrimSpace(stdout)), err
-}
-
 func loadSourceConfig(detector *detect.Detector, sourcePath string) {
 	if !fs.DirExists(sourcePath) {
+		logger.Debug("skipping additional config: source path does not exist: path=%q", sourcePath)
 		return
 	}
 
@@ -413,8 +444,9 @@ func loadSourceConfig(detector *detect.Detector, sourcePath string) {
 	}
 }
 
-func (s *Scanner) cloneGitRepo(ctx context.Context, cloneURL string, opts proto.Opts) (string, string, error) {
+func (s *Scanner) cloneGitRepo(ctx context.Context, cloneURL string, opts proto.Opts) (git.RepoInfo, error) {
 	cloneArgs := []string{"clone"}
+	gitRepoInfo := git.RepoInfo{}
 
 	if len(opts.Proxy) > 0 {
 		cloneArgs = append(cloneArgs, "--config")
@@ -424,15 +456,16 @@ func (s *Scanner) cloneGitRepo(ctx context.Context, cloneURL string, opts proto.
 	// The --[no-]single-branch flags are still needed with mirror due to how
 	// things like --depth and --shallow-since behave
 	if len(opts.Branch) > 0 {
-		if !remoteGitRefExists(ctx, cloneURL, opts.Branch) {
-			return "", "", fmt.Errorf("remote ref does not exist: ref=%q", opts.Branch)
+		if !git.RemoteRefExists(ctx, cloneURL, opts.Branch) {
+			return gitRepoInfo, fmt.Errorf("remote ref does not exist: ref=%q", opts.Branch)
 		}
-
+		gitRepoInfo.IsBare = true
 		cloneArgs = append(cloneArgs, "--bare")
 		cloneArgs = append(cloneArgs, "--single-branch")
 		cloneArgs = append(cloneArgs, "--branch")
 		cloneArgs = append(cloneArgs, opts.Branch)
 	} else {
+		gitRepoInfo.IsBare = true
 		cloneArgs = append(cloneArgs, "--mirror")
 		cloneArgs = append(cloneArgs, "--no-single-branch")
 	}
@@ -459,46 +492,40 @@ func (s *Scanner) cloneGitRepo(ctx context.Context, cloneURL string, opts proto.
 	// Include the clone URL
 	gitDir := filepath.Join(s.clonesDir, id.ID())
 	cloneArgs = append(cloneArgs, cloneURL, gitDir)
-	gitClone := gitCommand(ctx, cloneArgs...)
+	gitClone := git.CommandContext(ctx, cloneArgs...)
+	gitRepoInfo.GitDir = gitDir
 
 	logger.Debug("executing: %s", gitClone)
 	if output, err := gitClone.CombinedOutput(); err != nil {
-		return "", gitDir, fmt.Errorf("git clone failed: %v cmd=%q output=%q", err, gitClone, output)
+		return gitRepoInfo, fmt.Errorf("git clone failed: %w cmd=%q output=%q", err, gitClone, output)
 	}
 
 	if ctx != nil && ctx.Err() == context.DeadlineExceeded {
-		return "", "", fmt.Errorf("clone timeout exceeded: %v", ctx.Err())
+		return gitRepoInfo, fmt.Errorf("clone timeout exceeded: %w", ctx.Err())
 	}
 
-	sourcePath, err := checkoutGitSourceConfigFiles(ctx, gitDir)
+	return gitRepoInfo, nil
+}
+
+// tempCheckoutGitSourceConfigFiles is used for bare clones that don't already
+// have working trees. The scanner currently expects certain files to exist
+// on the file system for loading additional repo configuration. This creates
+// a worktree in the repo that's unique to this scan that can be safely
+// deleted after the scan completes. To keep things light, it only checks out
+// the relevant config files and not the rest of the tree's content.
+func tempCheckoutGitSourceConfigFiles(ctx context.Context, gitDir, gitRef string) (string, error) {
+	worktreePath, err := os.MkdirTemp(gitDir, "leaktk-worktree.")
 	if err != nil {
-		logger.Debug("could not checkout source config files: %v clone_url=%q", err, cloneURL)
+		return "", fmt.Errorf("could not create worktree directory: %w", err)
 	}
-
-	return sourcePath, gitDir, nil
-}
-
-func remoteGitRefExists(ctx context.Context, cloneURL, ref string) bool {
-	cmd := gitCommand(ctx, "ls-remote", "--exit-code", "--quiet", cloneURL, ref) // #nosec G204
-	logger.Debug("executing: %s", cmd)
-	return cmd.Run() == nil
-}
-
-func checkoutGitSourceConfigFiles(ctx context.Context, gitDir string) (string, error) {
-	worktreePath := filepath.Join(gitDir, "leaktk-scan-source")
-
-	cmd := gitCommand(ctx, "-C", gitDir, "worktree", "add", "--no-checkout", worktreePath) // #nosec G204
-	logger.Debug("executing: %s", cmd)
-	if err := cmd.Run(); err != nil {
-		return worktreePath, fmt.Errorf("could not create worktree: %v cmd=%q", err, cmd)
+	if len(gitRef) == 0 {
+		gitRef = "HEAD"
 	}
-
-	cmd = gitCommand(ctx, "-C", worktreePath, "checkout", "-f", "HEAD", "--", ".gitleaks*") // #nosec G204
+	cmd := git.CommandContext(ctx, "-C", gitDir, "--work-tree", worktreePath, "restore", "--source", gitRef, ".gitleaks*")
 	logger.Debug("executing: %s", cmd)
-	if err := cmd.Run(); err != nil {
-		return worktreePath, fmt.Errorf("could not checkout gitleaks files: %v cmd=%q", err, cmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return worktreePath, fmt.Errorf("could not checkout scanner config files: %w cmd=%q (%s)", err, cmd, string(out))
 	}
-
 	return worktreePath, nil
 }
 


### PR DESCRIPTION
# Overview

This implements some of the features in https://github.com/leaktk/leaktk/issues/238:

- The scaffolding for future hooks and installers
- Git pre-commit and pre-receive hooks and installer
- Docs referenced by those hooks

# TODO

- [x] Finish the installer
- [x] Test git.pre-commit
- [x] Test git.pre-receive
- [x] Ensure separate leaktk processes can't write the patterns file at the same time.
- [x] Make sure all the doc link refs use the commit of the built version (or fall back on HEAD)
- [x] Have pre-commit properly include the .gitleaks.toml from the repo
- [x] Make sure the tests pass
- [x] Write the docs referenced by links
- [x] Do final spot check before marking it as ready for review


## Test Cases

Integration test cases can be added to `./test/integration` now.