### PR TITLE
Update macOS notarization configuration in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,10 @@ builds:
 
 notarize:
   macos:
-    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+    - id: leaktk-notarize
+      ids:
+       - "{{ .ProjectName }}"
+      enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
       sign:
         certificate: "{{.Env.MACOS_SIGN_P12}}"
         password: "{{.Env.MACOS_SIGN_PASSWORD}}"


### PR DESCRIPTION
The notarization configuration is incorrect. Since id was added to builds it doesn't seem to find them. This /should/ bridge the gap.