### PR TITLE
Add CGO_ENABLED=0 to install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -77,7 +77,7 @@ If you have Go installed (version 1.23.3 or newer is recommended), you can insta
 To install the latest version:
 
 ```sh
-GOBIN="${HOME}/.local/bin" go install github.com/leaktk/leaktk@latest
+CGO_ENABLED=0 GOBIN="${HOME}/.local/bin" go install github.com/leaktk/leaktk@latest
 ```
 
 Or to install a specific version:


### PR DESCRIPTION
We don't build with CGO_ENABLED so the install docs should have that in the build options too. 