### PR TITLE
Avoid Mac notarization

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,7 +65,7 @@ homebrew_casks:
       post:
         install: |
           if OS.mac?
-            system_command "/usr/bin/codesign", args: ["-f", "-s", "-", "#{staged_path}/leaktk"]
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/leaktk"]
           end
 
 # https://goreleaser.com/customization/package/dockers_v2/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,19 +15,6 @@ builds:
     ldflags:
       - -X github.com/leaktk/{{ .ProjectName }}/pkg/version.Version={{ .Version }} -X github.com/leaktk/{{ .ProjectName }}/pkg/version.Commit={{ .FullCommit }}
 
-notarize:
-  macos:
-    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
-      ids:
-       - "{{ .ProjectName }}"
-      sign:
-        certificate: "{{.Env.MACOS_SIGN_P12}}"
-        password: "{{.Env.MACOS_SIGN_PASSWORD}}"
-      notarize:
-        issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
-        key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
-        key: "{{.Env.MACOS_NOTARY_KEY}}"
-
 archives:
   - formats: tar.xz
     name_template: >-
@@ -74,6 +61,12 @@ homebrew_casks:
       fish: "completions/fish/leaktk.fish"
     url:
       verified: github.com/leaktk/leaktk
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/codesign", args: ["-f", "-s", "-", "#{staged_path}/leaktk"]
+          end
 
 # https://goreleaser.com/customization/package/dockers_v2/
 dockers_v2:

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,8 @@ Releases page for leaktk/leaktk](https://github.com/leaktk/leaktk/releases).
    (e.g., leaktk\_X.Y.Z\_linux\_amd64.tar.gz,
    leaktk\_X.Y.Z\_windows\_amd64.zip).
 4. Extract the archive.
-5. (Optional) Move the leaktk (or leaktk.exe on Windows) binary to a directory
+5. (For macOS) Run: `/usr/bin/codesign -f -s - PATH_TO_LEAKTK_BIN` (replacing `PATH_TO_LEAKTK_BIN` with the path to the extracted binary file)
+6. (Optional) Move the leaktk (or leaktk.exe on Windows) binary to a directory
    in your system's PATH (e.g., /usr/local/bin or C:\\Windows\\System32).
 
 ## **📦 Using Docker/Podman (Container Image)**
@@ -30,7 +31,7 @@ Official container images are hosted on Quay.io.
 
 ```sh
 # Replace TAG with a specific tag from https://quay.io/repository/leaktk/leaktk?tab=tags
-podman pull quay.io/leaktk/leaktk:TAG 
+podman pull quay.io/leaktk/leaktk:TAG
 ```
 
 You can find available tags on [Quay.io for LeakTK](https://quay.io/repository/leaktk/leaktk?tab=tags).

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,11 @@ Releases page for leaktk/leaktk](https://github.com/leaktk/leaktk/releases).
    (e.g., leaktk\_X.Y.Z\_linux\_amd64.tar.gz,
    leaktk\_X.Y.Z\_windows\_amd64.zip).
 4. Extract the archive.
-5. (For macOS) Run: `/usr/bin/codesign -f -s - PATH_TO_LEAKTK_BIN` (replacing `PATH_TO_LEAKTK_BIN` with the path to the extracted binary file)
+5. (For macOS) You may have to remove the quarantine flag if downloading it using a browser:
+   ```sh
+   # Replace PATH_TO_LEAKTK_BIN with the path to the extracted leaktk binary
+   xattr -d com.apple.quarantine PATH_TO_LEAKTK_BIN
+   ```
 6. (Optional) Move the leaktk (or leaktk.exe on Windows) binary to a directory
    in your system's PATH (e.g., /usr/local/bin or C:\\Windows\\System32).
 


### PR DESCRIPTION
~There seems to be an issue with quill's signatures that we need to work through and this is a workaround for now until we can figure it out.~

A lot of the problems go away if we don't notarize it and just strip the quarantine flag. Home brew will be automated and I updated the docs for the users.