### PR TITLE
Adding leaktk scan kinds in usage with examples

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -251,7 +251,7 @@ func scanCommand() *cobra.Command {
 
 	flags := scanCommand.Flags()
 	flags.String("id", id.ID(), "Set the ID request ID that will be displayed in the response and logs")
-	flags.StringP("kind", "k", "GitRepo", "Specify the kind of resource being scanned")
+	flags.StringP("kind", "k", "GitRepo", "Specify the kind of resource being scanned (ContainerImage, Files, GitRepo, JSONData, Text, URL)")
 	flags.StringP("options", "o", "{}", "Provide scan specific options formatted as JSON")
 	flags.Int("leak-exit-code", 0, "Exit with this code when leaks are detected (default 0)")
 	flags.String("gitleaks-config", "", "Load a custom gitleaks config")

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -15,10 +15,24 @@ for it.
 # Listen for requests
 leaktk listen < ./examples/requests.jsonl
 
-# Run a single scan
+# Scan a git repository (default kind)
 leaktk scan 'https://github.com/leaktk/fake-leaks.git'
+
+# Scan a container image
+leaktk scan --kind ContainerImage 'quay.io/leaktk/fake-leaks:v1.0.1'
+
+# Scan local files or directories
+leaktk scan --kind Files /path/to/directory
+
+# Scan JSON data inline or from a file
 leaktk scan --kind JSONData '{"key": "-----BEGIN PRIVATE KEY-----c5602d28d0f21422dfc7b572b17e6b138c1b49fd7f477d4c5c961e0756f1ff70-----END PRIVATE KEY-----"}'
 leaktk scan --kind JSONData '@/path/to/some-file.json'
+
+# Scan arbitrary text
+leaktk scan --kind Text 'some text to scan for secrets'
+
+# Fetch and scan a URL
+leaktk scan --kind URL 'https://raw.githubusercontent.com/leaktk/fake-leaks/main/keys/tls/server.key'
 
 # See more options
 leaktk help
@@ -27,8 +41,16 @@ leaktk help
 The scanner should always generate a response to each request even if there
 were errors during the scan.
 
-For most scans `leaktk scan [--kind=<kind>] <resource>` is enough, but more
-information about the supported kinds of resources and specific options for
-each resource can be found in the docs for [listen mode](listen.md). The
-options listed in that doc can be provided with the `--options` flag and
-should be formated as a JSON string.
+For most scans `leaktk scan [--kind=<kind>] <resource>` is enough. The
+supported kinds are:
+
+- **ContainerImage**: Scan container images
+- **Files**: Scan local filesystem paths
+- **GitRepo**: Scan git repositories (default)
+- **JSONData**: Scan JSON data for URLs to fetch and scan
+- **Text**: Scan arbitrary text
+- **URL**: Fetch and scan a URL
+
+More information about each kind and specific options can be found in the docs
+for [listen mode](listen.md). The options listed in that doc can be provided
+with the `--options` flag and should be formatted as a JSON string.


### PR DESCRIPTION
Adding `leaktk scan` kinds that are supported with some examples for easier/direct reference.