### PR TITLE
Fixing issue #100 - adding grep scan functionality

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
-	"regexp"
 
 	"github.com/spf13/cobra"
 
@@ -107,13 +107,13 @@ func runScan(cmd *cobra.Command, args []string) {
 		if err != nil {
 			logger.Fatal("could not create a temp config: %v", err)
 		}
-		defer os.Remove(tmpFile.Name())
+		defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 		if _, err := tmpFile.WriteString(buildGitleaksConfig(grepPattern)); err != nil {
-			tmpFile.Close()
+			_ = tmpFile.Close()
 			logger.Fatal("could not write temp config: %v", err)
 		}
-		tmpFile.Close()
+		_ = tmpFile.Close()
 
 		gitleaksConfig = tmpFile.Name()
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -283,6 +283,9 @@ func scanCommand() *cobra.Command {
 	flags.String("gitleaks-config", "", "Load a custom gitleaks config")
 	flags.StringP("grep", "g", "", "Scan using ad-hoc regex instead of the configured patterns")
 
+	// Ensure incompatible flags can't be combined
+	scanCommand.MarkFlagsMutuallyExclusive("grep", "gitleaks-config")
+
 	return scanCommand
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
 
 	"github.com/leaktk/leaktk/pkg/config"
@@ -290,21 +291,21 @@ func scanCommand() *cobra.Command {
 }
 
 func buildGitleaksConfig(pattern string) string {
-        var rule struct {
-                ID          string `toml:"id"`
-                Description string `toml:"description"`
-                Regex       string `toml:"regex"`
-        }
-        rule.ID = id.ID("grep", pattern)
-        rule.Description = "Grep Pattern Match"
-        rule.Regex = pattern
+	var rule struct {
+		ID          string `toml:"id"`
+		Description string `toml:"description"`
+		Regex       string `toml:"regex"`
+	}
+	rule.ID = id.ID("grep", pattern)
+	rule.Description = "Grep Pattern Match"
+	rule.Regex = pattern
 
-        data, err := toml.Marshal(&rule)
-        if err != nil {
-                logger.Fatal("could not marshal grep rule: %v", err)
-        }
+	data, err := toml.Marshal(&rule)
+	if err != nil {
+		logger.Fatal("could not marshal grep rule: %v", err)
+	}
 
-        return fmt.Sprintf("[[rules]]\n%s\n", string(data))
+	return fmt.Sprintf("[[rules]]\n%s\n", string(data))
 }
 
 func readLine(reader *bufio.Reader) ([]byte, error) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -290,9 +290,21 @@ func scanCommand() *cobra.Command {
 }
 
 func buildGitleaksConfig(pattern string) string {
-	ruleID := id.ID(pattern)
+        var rule struct {
+                ID          string `toml:"id"`
+                Description string `toml:"description"`
+                Regex       string `toml:"regex"`
+        }
+        rule.ID = id.ID("grep", pattern)
+        rule.Description = "Grep Pattern Match"
+        rule.Regex = pattern
 
-	return fmt.Sprintf("[[rules]]\nid = %q\ndescription = \"Custom Regex\"\nregex = '''%s'''\n", ruleID, pattern)
+        data, err := toml.Marshal(&rule)
+        if err != nil {
+                logger.Fatal("could not marshal grep rule: %v", err)
+        }
+
+        return fmt.Sprintf("[[rules]]\n%s\n", string(data))
 }
 
 func readLine(reader *bufio.Reader) ([]byte, error) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"regexp"
 
 	"github.com/spf13/cobra"
 
@@ -87,9 +88,34 @@ func runScan(cmd *cobra.Command, args []string) {
 		logger.Fatal("invalid leak-exit-code: %v", err)
 	}
 
+	grepPattern, err := cmd.Flags().GetString("grep")
+	if err != nil {
+		logger.Fatal("invalid grep: %v", err)
+	}
+
 	gitleaksConfig, err := cmd.Flags().GetString("gitleaks-config")
 	if err != nil {
 		logger.Fatal("invalid gitleaks-config: %v", err.Error())
+	}
+
+	if len(grepPattern) != 0 {
+		if _, err := regexp.Compile(grepPattern); err != nil {
+			logger.Fatal("invalid grep pattern: %v", err)
+		}
+
+		tmpFile, err := os.CreateTemp("", "leaktk-grep-*.toml")
+		if err != nil {
+			logger.Fatal("could not create a temp config: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		if _, err := tmpFile.WriteString(buildGitleaksConfig(grepPattern)); err != nil {
+			tmpFile.Close()
+			logger.Fatal("could not write temp config: %v", err)
+		}
+		tmpFile.Close()
+
+		gitleaksConfig = tmpFile.Name()
 	}
 
 	// Providing a gitleaks-config via command line arguments takes
@@ -255,8 +281,15 @@ func scanCommand() *cobra.Command {
 	flags.StringP("options", "o", "{}", "Provide scan specific options formatted as JSON")
 	flags.Int("leak-exit-code", 0, "Exit with this code when leaks are detected (default 0)")
 	flags.String("gitleaks-config", "", "Load a custom gitleaks config")
+	flags.StringP("grep", "g", "", "Scan using ad-hoc regex instead of the configured patterns")
 
 	return scanCommand
+}
+
+func buildGitleaksConfig(pattern string) string {
+	ruleID := id.ID(pattern)
+
+	return fmt.Sprintf("[[rules]]\nid = %q\ndescription = \"Custom Regex\"\nregex = '''%s'''\n", ruleID, pattern)
 }
 
 func readLine(reader *bufio.Reader) ([]byte, error) {


### PR DESCRIPTION
Added logic to `scan` to allow for ad-hoc regex to be used during scans by adding a `--grep` flag.

Usage example: `leaktk scan --grep 'secret="[^\"]+"' --resource https://github.com/leaktk/fake-leaks.git`